### PR TITLE
Ghoul2 importer updates

### DIFF
--- a/JAFilesystem.py
+++ b/JAFilesystem.py
@@ -94,3 +94,12 @@ def FindFile(relpath, prefix, extensions):
 
 def FileExists(path: str) -> bool:
     return os.path.isfile(path)
+
+
+def PathToFile(relpath, base_path):
+    absPath = AbsPath(relpath, base_path)
+    return os.path.dirname(absPath) + os.path.sep
+
+
+def FileList(fullpath):
+    return os.listdir(fullpath)

--- a/JAG2AnimationCFG.py
+++ b/JAG2AnimationCFG.py
@@ -74,8 +74,8 @@ class AnimationSequence():
         new_frame.name = nla_strip.action.name
         new_frame.start_frame = int(nla_strip.frame_start + offset)
         new_frame.num_frames = int(nla_strip.frame_end - nla_strip.frame_start + length_difference)
-        new_frame.loop = False
-        new_frame.fps = int(fps)
+        new_frame.loop = bool(nla_strip.action.loop_frame)
+        new_frame.fps = int(nla_strip.action.fps)
         return new_frame
 
 

--- a/JAG2AnimationCFG.py
+++ b/JAG2AnimationCFG.py
@@ -1,0 +1,180 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from .mod_reload import reload_modules
+reload_modules(locals(), __package__, ["JAFilesystem"], [".casts", ".error_types"])  # nopep8
+
+import bpy
+from . import JAFilesystem
+from .error_types import ErrorMessage
+from typing import List, Tuple
+
+
+class AnimationSequence():
+    def __init__(self):
+        self.name = ""
+        self.start_frame = -1
+        self.num_frames = -1
+        self.loop = False
+        self.fps = -1
+
+    def __str__(self):
+        return "{name}\t\t{start}\t{frames}\t{loop}\t{fps}".format(
+            name = self.name,
+            start = self.start_frame,
+            frames = self.num_frames,
+            loop = 0 if self.loop else -1,
+            fps = self.fps
+        )
+
+    @classmethod
+    def from_cfg_line(cls, txt_line):
+        try:
+            # remove comments inline first, someone might have annotated these
+            line = txt_line.split("//")[0]
+            name, sf, nf, l, fps = line.split()
+            new_frame = cls()
+            new_frame.name = name
+            new_frame.start_frame = int(sf)
+            new_frame.num_frames = int(nf)
+            new_frame.loop = int(l) != -1
+            new_frame.fps = int(fps)
+            return new_frame
+        except Exception:
+            return None
+        
+    @classmethod
+    def from_blender_markers(cls, marker1, marker2, fps, offset = 0):
+        new_frame = cls()
+        new_frame.name = marker1.name
+        new_frame.start_frame = int(marker1.frame + offset)
+        new_frame.num_frames = int(marker2.frame - marker1.frame)
+        new_frame.loop = False
+        new_frame.fps = int(fps)
+        return new_frame
+    
+    @classmethod
+    def from_blender_strip(cls, nla_strip, length_difference, fps, offset = 0):
+        new_frame = cls()
+        new_frame.name = nla_strip.action.name
+        new_frame.start_frame = int(nla_strip.frame_start + offset)
+        new_frame.num_frames = int(nla_strip.frame_end - nla_strip.frame_start + length_difference)
+        new_frame.loop = False
+        new_frame.fps = int(fps)
+        return new_frame
+
+
+class AnimationCGF():
+
+    def __init__(self):
+        self.sequences : List[AnimationSequence] = []
+
+    def __str__(self):
+        lines = [str(seq) for seq in self.sequences]
+        return "\n".join(lines)
+
+    def load_from_cfg(self, cfg_file_path) -> Tuple[bool, ErrorMessage]:
+        success, cfg_abs = JAFilesystem.FindFile(cfg_file_path + "/animation", "", ["cfg"])
+        if not success:
+            print("Could not find file: ", cfg_abs, sep="")
+            return False, ErrorMessage("Could not find the animation.cfg next to the .gla file")
+        
+        try:
+            file = open(cfg_abs, mode="r")
+        except IOError:
+            print("Could not open file: ", cfg_abs, sep="")
+            return False, ErrorMessage("Could not open skin!")
+        for line in file:
+            if line.startswith("//") or line.strip() == "":
+                continue
+            seqence = AnimationSequence().from_cfg_line(line)
+            if seqence:
+                self.sequences.append(seqence)
+            else:
+                print("Could not parse following line in animations.cfg", line)
+        self.sequences.sort(key=lambda sequence: sequence.start_frame)
+        return True, ErrorMessage("Nothing")
+    
+    def from_blender_markers(self, context, offset):
+        start_frame = context.scene.frame_start
+        offset -= start_frame
+        end_frame = context.scene.frame_end
+        base_fps = context.scene.render.fps
+
+        blender_markers = [
+            marker for marker in context.scene.timeline_markers if (
+                marker.frame >= start_frame and marker.frame <= end_frame+1)
+            ]
+        blender_markers.sort(key=lambda marker: marker.frame)
+
+        if (len(blender_markers) == 0 or 
+            (len(blender_markers) == 1 and blender_markers[0].frame == end_frame+1)):
+            return False, ErrorMessage("No timeline markers found! Add Markers to label animations.")
+
+        if blender_markers[len(blender_markers)-1].frame != end_frame+1:
+            blender_markers.append(
+                context.scene.timeline_markers.new("LAST_EXPORT_FRAME", frame = end_frame+1))
+
+        for marker1, marker2 in zip(blender_markers[:-1], blender_markers[1:]):
+            self.sequences.append(AnimationSequence().from_blender_markers(
+                marker1,
+                marker2,
+                base_fps,
+                offset
+            ))
+
+        last_frame = context.scene.timeline_markers.get("LAST_EXPORT_FRAME")
+        if last_frame:
+            context.scene.timeline_markers.remove(last_frame)
+
+        return True, ErrorMessage("Nothing")
+    
+    def from_blender_nla_tracks(self, context, offset):
+        start_frame = context.scene.frame_start
+        offset -= start_frame
+        end_frame = context.scene.frame_end
+        base_fps = context.scene.render.fps
+
+        skeleton_object = bpy.data.objects.get("skeleton_root")
+        if skeleton_object is None:
+            return False, ErrorMessage("Could not find skeleton object: skeleton_root")
+        if skeleton_object.animation_data is None:
+            return False, ErrorMessage('Skeleton object (skeleton_root) does not have animation data')
+        if len(skeleton_object.animation_data.nla_tracks) == 0:
+            return False, ErrorMessage("Couldn't find NLA tracks for the Skeleton object: skeleton_root")
+
+        blender_strips = []
+        for nla_track in [track for track in skeleton_object.animation_data.nla_tracks]:
+            length_differnce = 0 if nla_track.name.startswith("Stills Layer") else 1
+            for nla_strip in [strip for strip in nla_track.strips if strip.frame_start >= start_frame and strip.frame_start <= end_frame]:
+                blender_strips.append((nla_strip, length_differnce))
+        blender_strips.sort(key=lambda strip: strip[0].frame_start)
+
+        if len(blender_strips) == 0:
+            return False, ErrorMessage("No NLA strips found! Add animation strips to label animations.")
+
+        for strip, length_differnce in blender_strips:
+            self.sequences.append(AnimationSequence().from_blender_strip(
+                strip,
+                length_differnce,
+                base_fps,
+                offset
+            ))
+
+        return True, ErrorMessage("Nothing")
+        

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -776,10 +776,10 @@ class GLA:
         # first check if there's already an armature object called skeleton_root. Try using that.
         if "skeleton_root" in bpy.data.objects:
             print("Found a skeleton_root object, trying to use it.")
-            self.skeleton_object = bpy.data.objects["skeleton_root"]
+            self.skeleton_object = bpy_generic_cast(bpy.types.Object, bpy.data.objects["skeleton_root"])
             if self.skeleton_object.type != 'ARMATURE':
                 return False, ErrorMessage("Existing skeleton_root object is no armature!")
-            self.skeleton_armature = self.skeleton_object.data
+            self.skeleton_armature = bpy_generic_cast(bpy.types.Armature, self.skeleton_object.data)
             self.skeleton_object.g2_prop_scale = self.header.scale * 100
         # If there's no skeleton, there may yet still be an armature. Use that.
         elif "skeleton_root" in bpy.data.armatures:

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -468,6 +468,8 @@ class MdxaAnimation:
 
             for sequenceNum, sequence in enumerate(animations.sequences):
                 action = bpy.data.actions.new(sequence.name)
+                action.loop_frame = sequence.loop
+                action.fps = sequence.fps
                 armature.animation_data.action = action
                 strip = None
                 nla_track_index = 1

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -17,11 +17,12 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from .mod_reload import reload_modules
-reload_modules(locals(), __package__, ["JAStringhelper", "JAG2Constants", "JAG2Math", "MrwProfiler"], [".casts", ".error_types"])  # nopep8
+reload_modules(locals(), __package__, ["JAStringhelper", "JAG2AnimationCFG", "JAG2Constants", "JAG2Math", "MrwProfiler"], [".casts", ".error_types"])  # nopep8
 
 from . import JAStringhelper
 from . import JAG2Constants
 from . import JAG2Math
+from . import JAG2AnimationCFG
 from . import MrwProfiler
 from .casts import optional_cast, downcast, bpy_generic_cast, matrix_getter_cast, matrix_overload_cast, vector_getter_cast
 from .error_types import ErrorMessage, NoError, ensureListIsGapless
@@ -391,7 +392,7 @@ class MdxaAnimation:
         assert (file.tell() == header.ofsCompBonePool)
         self.bonePool.saveToFile(file)
 
-    def saveToBlender(self, skeleton: MdxaSkel, armature: bpy.types.Object, scale):
+    def saveToBlender(self, skeleton: MdxaSkel, armature: bpy.types.Object, scale, animations: Optional[JAG2AnimationCFG.AnimationCGF] = None):
         import time
         startTime = time.time()
         #   Bone Position Set Order
@@ -441,58 +442,143 @@ class MdxaAnimation:
         ])
 
         # show progress every 1000 steps, but at least 10 times)
-        progressStep = min(1000, round(numFrames / 10))
         nextProgressDisplayTime = time.time() + PROGRESS_UPDATE_INTERVAL
-        lastFrameNum = 0
 
         #   Export animation
         # enter pose mode to make edits to the bone transforms
         bpy.ops.object.mode_set(mode='POSE', toggle=False)
-        for frameNum, frame in enumerate(self.frames):
-            # show progress bar / remaining time
-            if time.time() >= nextProgressDisplayTime:
-                numProcessedFrames = frameNum - lastFrameNum
-                framesRemaining = numFrames - frameNum
-                # only take the frames since the last update into account since the speed varies.
-                # speed's roughly inversely proportional to the current frame number so I could use that to predict remaining time...
-                timeRemaining = PROGRESS_UPDATE_INTERVAL * framesRemaining / numProcessedFrames
+        if animations:
+            lastSequenceNum = 0
+            nla_seqence_tracks = []
+            nla_stills_tracks = []
+            # create NLA tracks keeping track of all animations
+            armature.animation_data_create()
+            armature.animation_data.use_nla = True
+            nla_track = armature.animation_data.nla_tracks.new()
+            nla_track.name = "Sequences Layer 1"
+            nla_track.select = True
+            # Only make the first layer visable
+            nla_track.is_solo = True
+            nla_seqence_tracks.append(nla_track)
 
-                print("Frame {}/{} - {:.2%} - remaining time: ca. {:.0f}m {:.0f}s".format(
-                    frameNum, numFrames, frameNum / numFrames, timeRemaining // 60, timeRemaining % 60))
+            # NLA strips can't be 0 frames long, so keep them seperated
+            nla_track = armature.animation_data.nla_tracks.new()
+            nla_track.name = "Stills Layer 1"
+            nla_stills_tracks.append(nla_track)
 
-                lastFrameNum = frameNum
-                nextProgressDisplayTime = time.time() + PROGRESS_UPDATE_INTERVAL
+            for sequenceNum, sequence in enumerate(animations.sequences):
+                action = bpy.data.actions.new(sequence.name)
+                armature.animation_data.action = action
+                strip = None
+                nla_track_index = 1
+                # pick a nla track that can hold the animation, overlapping strips is not possible
+                while strip is None and nla_track_index < 9:
+                    track_name = "Stills Layer {}".format(nla_track_index) if sequence.num_frames == 1 else "Sequences Layer {}".format(nla_track_index)
+                    nla_track = armature.animation_data.nla_tracks.get(track_name)
+                    if nla_track is None:
+                        nla_track = armature.animation_data.nla_tracks.new()
+                        nla_track.name = track_name
+                    nla_track.select = True
+                    try:
+                        strip = nla_track.strips.new(action.name, sequence.start_frame, action)
+                        strip.action_frame_start = 0
+                        strip.action_frame_end = sequence.num_frames-1
+                    except Exception:
+                        strip = None
+                    nla_track_index += 1
 
-            # absolute offset matrices by bone index
-            offsets: Dict[int, mathutils.Matrix] = {}
-            for index in hierarchyOrder:
-                mdxaBone = skeleton.bones[index]
-                assert (mdxaBone.index == index)
-                bonePoolIndex = frame.boneIndices[index]
-                # get offset transformation matrix, relative to parent
-                offset = downcast(List[JAG2Math.CompBone], self.bonePool.bones)[bonePoolIndex].matrix
-                # turn into absolute offset matrix (already is if this is top level bone)
-                if mdxaBone.parent != -1:
-                    offset = matrix_overload_cast(offsets[mdxaBone.parent] @ offset)
-                # save this absolute offset for use by children
-                offsets[index] = offset
-                # calculate the actual position
-                transformation = matrix_overload_cast(offset @ basePoses[index])
-                # flip axes as required for blender bone
-                JAG2Math.GLABoneRotToBlender(transformation)
+                # show progress bar / remaining time
+                if time.time() >= nextProgressDisplayTime:
+                    numProcessedFrames = sequenceNum - lastSequenceNum
+                    framesRemaining = len(animations.sequences) - sequenceNum
+                    # only take the frames since the last update into account since the speed varies.
+                    # speed's roughly inversely proportional to the current frame number so I could use that to predict remaining time...
+                    timeRemaining = PROGRESS_UPDATE_INTERVAL * framesRemaining / numProcessedFrames
 
-                pose_bone = bones[index]
-                # pose_bone.matrix = transformation * scaleMatrix
-                pose_bone.matrix = transformation
-                # in the _humanoid face, the scale gets changed. that messes the re-export up. FIXME: understand why. Is there a problem?
-                pose_bone.scale = [1, 1, 1]
-                # force the matrix to update, this is still slow, but faster than switching between pose and object mode
-                bpy.ops.pose.visual_transform_apply()
+                    print("Sequence {}/{} - {:.2%} - remaining time: ca. {:.0f}m {:.0f}s".format(
+                        sequenceNum, len(animations.sequences), sequenceNum / len(animations.sequences), timeRemaining // 60, timeRemaining % 60))
 
-            # Adding keyframes outside of calculating the transforms is apparently faster
-            for pose_bone in bones:
-                pose_bone.keyframe_insert('location', frame=frameNum)
-                pose_bone.keyframe_insert('rotation_quaternion', frame=frameNum)
+                    lastSequenceNum = sequenceNum
+                    nextProgressDisplayTime = time.time() + PROGRESS_UPDATE_INTERVAL
+
+                for i in range(sequence.num_frames):
+                    # absolute offset matrices by bone index
+                    offsets: Dict[int, mathutils.Matrix] = {}
+                    for index in hierarchyOrder:
+                        mdxaBone = skeleton.bones[index]
+                        assert (mdxaBone.index == index)
+                        bonePoolIndex = self.frames[sequence.start_frame + i].boneIndices[index]
+                        # get offset transformation matrix, relative to parent
+                        offset = downcast(List[JAG2Math.CompBone], self.bonePool.bones)[bonePoolIndex].matrix
+                        # turn into absolute offset matrix (already is if this is top level bone)
+                        if mdxaBone.parent != -1:
+                            offset = matrix_overload_cast(offsets[mdxaBone.parent] @ offset)
+                        # save this absolute offset for use by children
+                        offsets[index] = offset
+                        # calculate the actual position
+                        transformation = matrix_overload_cast(offset @ basePoses[index])
+                        # flip axes as required for blender bone
+                        JAG2Math.GLABoneRotToBlender(transformation)
+
+                        pose_bone = bones[index]
+                        # pose_bone.matrix = transformation * scaleMatrix
+                        pose_bone.matrix = transformation
+                        # in the _humanoid face, the scale gets changed. that messes the re-export up. FIXME: understand why. Is there a problem?
+                        pose_bone.scale = [1, 1, 1]
+                        # force the matrix to update, this is still slow, but faster than switching between pose and object mode
+                        bpy.ops.pose.visual_transform_apply()
+                    for pose_bone in bones:
+                        pose_bone.keyframe_insert('location', frame=i)
+                        pose_bone.keyframe_insert('rotation_quaternion', frame=i)
+            # remove action from the animation data to stop previewing a single action
+            armature.animation_data.action = None # type: ignore
+        else:
+            lastFrameNum = 0
+            for frameNum, frame in enumerate(self.frames):
+                # show progress bar / remaining time
+                if time.time() >= nextProgressDisplayTime:
+                    numProcessedFrames = frameNum - lastFrameNum
+                    framesRemaining = numFrames - frameNum
+                    # only take the frames since the last update into account since the speed varies.
+                    # speed's roughly inversely proportional to the current frame number so I could use that to predict remaining time...
+                    timeRemaining = PROGRESS_UPDATE_INTERVAL * framesRemaining / numProcessedFrames
+
+                    print("Frame {}/{} - {:.2%} - remaining time: ca. {:.0f}m {:.0f}s".format(
+                        frameNum, numFrames, frameNum / numFrames, timeRemaining // 60, timeRemaining % 60))
+
+                    lastFrameNum = frameNum
+                    nextProgressDisplayTime = time.time() + PROGRESS_UPDATE_INTERVAL
+
+                # absolute offset matrices by bone index
+                offsets: Dict[int, mathutils.Matrix] = {}
+                for index in hierarchyOrder:
+                    mdxaBone = skeleton.bones[index]
+                    assert (mdxaBone.index == index)
+                    bonePoolIndex = frame.boneIndices[index]
+                    # get offset transformation matrix, relative to parent
+                    offset = downcast(List[JAG2Math.CompBone], self.bonePool.bones)[bonePoolIndex].matrix
+                    # turn into absolute offset matrix (already is if this is top level bone)
+                    if mdxaBone.parent != -1:
+                        offset = matrix_overload_cast(offsets[mdxaBone.parent] @ offset)
+                    # save this absolute offset for use by children
+                    offsets[index] = offset
+                    # calculate the actual position
+                    transformation = matrix_overload_cast(offset @ basePoses[index])
+                    # flip axes as required for blender bone
+                    JAG2Math.GLABoneRotToBlender(transformation)
+
+                    pose_bone = bones[index]
+                    # pose_bone.matrix = transformation * scaleMatrix
+                    pose_bone.matrix = transformation
+                    # in the _humanoid face, the scale gets changed. that messes the re-export up. FIXME: understand why. Is there a problem?
+                    pose_bone.scale = [1, 1, 1]
+                    # force the matrix to update, this is still slow, but faster than switching between pose and object mode
+                    bpy.ops.pose.visual_transform_apply()
+
+                # Adding keyframes outside of calculating the transforms is apparently faster
+                for pose_bone in bones:
+                    pose_bone.keyframe_insert('location', frame=frameNum)
+                    pose_bone.keyframe_insert('rotation_quaternion', frame=frameNum)
 
         # enter object mode when done
         bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
@@ -500,6 +586,7 @@ class MdxaAnimation:
 
 class AnimationLoadMode(Enum):
     NONE = 'NONE'
+    CFG = "CFG"
     ALL = 'ALL'
     RANGE = 'RANGE'
 
@@ -544,7 +631,7 @@ class GLA:
         profiler.stop("reading bone hierarchy")
         if loadAnimation != AnimationLoadMode.NONE:
             profiler.start("reading animations")
-            if loadAnimation == AnimationLoadMode.ALL:
+            if loadAnimation in [AnimationLoadMode.ALL, AnimationLoadMode.CFG]:
                 success, message = self.animation.loadFromFile(
                     file, self.header, 0, -1)
             else:
@@ -765,7 +852,7 @@ class GLA:
         assert (file.tell() == self.header.ofsEnd)
         return True, NoError
 
-    def saveToBlender(self, scene_root: bpy.types.Object, useAnimation: bool, skeletonFixes: JAG2Constants.SkeletonFixes) -> Tuple[bool, ErrorMessage]:
+    def saveToBlender(self, scene_root: bpy.types.Object, useAnimation: bool, skeletonFixes: JAG2Constants.SkeletonFixes, animations: Optional[JAG2AnimationCFG.AnimationCGF] = None) -> Tuple[bool, ErrorMessage]:
         print("Applying skeleton/skeleton to Blender")
         profiler = MrwProfiler.SimpleProfiler(True)
         # default skeleton = no skeleton.
@@ -823,7 +910,7 @@ class GLA:
                     print("=== Profile stop ===")
                 else:
                     self.animation.saveToBlender(
-                        self.skeleton, self.skeleton_object, self.header.scale)
+                        self.skeleton, self.skeleton_object, self.header.scale, animations)
                 profiler.stop("applying animations")
 
             # that's all
@@ -856,6 +943,6 @@ class GLA:
                 print("=== Profile stop ===")
             else:
                 self.animation.saveToBlender(
-                    self.skeleton, self.skeleton_object, self.header.scale)
+                    self.skeleton, self.skeleton_object, self.header.scale, animations)
             profiler.stop("applying animations")
         return True, NoError

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -470,7 +470,11 @@ class MdxaAnimation:
                 action = bpy.data.actions.new(sequence.name)
                 action.loop_frame = sequence.loop
                 action.fps = sequence.fps
+                slot = action.slots.get("Armature")
+                if not slot:
+                    slot = action.slots.new('OBJECT', "Armature")
                 armature.animation_data.action = action
+                armature.animation_data.action_slot = slot
                 strip = None
                 nla_track_index = 1
                 # pick a nla track that can hold the animation, overlapping strips is not possible
@@ -485,6 +489,7 @@ class MdxaAnimation:
                         strip = nla_track.strips.new(action.name, sequence.start_frame, action)
                         strip.action_frame_start = 0
                         strip.action_frame_end = sequence.num_frames-1
+                        strip.action_slot = slot
                     except Exception:
                         strip = None
                     nla_track_index += 1
@@ -533,6 +538,7 @@ class MdxaAnimation:
                         pose_bone.keyframe_insert('location', frame=i)
                         pose_bone.keyframe_insert('rotation_quaternion', frame=i)
             # remove action from the animation data to stop previewing a single action
+            armature.animation_data.action_slot = None # type: ignore
             armature.animation_data.action = None # type: ignore
         else:
             lastFrameNum = 0

--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -69,10 +69,9 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
             "Many models try to force you to use the skin. "
             "Enable this to try to circumvent that. "
             "(Usually works well, but skins should be preferred.)")]
-        for index, skin in enumerate(skin_files):
+        for skin in skin_files:
             if skin.endswith("_default.skin"):
                 items.append((skin, skin.split(".")[0], ""))
-                break
         items.append((" ", "None", "Use file internal paths. "))
         
         return items + [(skin, skin.split(".")[0], "")

--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -63,8 +63,8 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
         except Exception as e:
             print("Could not open skin files, error: ", e)
 
-        return [(" ", "None", "")] + [(skin, skin.split(".")[0], "")
-                for skin in sorted(skin_files)]
+        return [(" ", "None", ""), ("DEFAULT", "<modelname>_default", "")] + [(skin, skin.split(".")[0], "")
+                for skin in sorted(skin_files) if not skin.endswith("_default.skin")]
     
     # properties
     filepath: bpy.props.StringProperty(
@@ -74,7 +74,7 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
     skin: bpy.props.EnumProperty(
         items=skin_list_cb,
         name="Skin",
-        default=0, # type: ignore
+        default=1, # type: ignore
         description="The skin to load, choose none to use file internal paths"
     ) # pyright: ignore [reportInvalidTypeForm]
     guessTextures: bpy.props.BoolProperty(
@@ -162,7 +162,9 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
             return {'FINISHED'}
         # output to blender
         skin = ""
-        if self.skin.strip() != "":
+        if self.skin == "DEFAULT":
+            skin = filepath + "_default.skin"
+        elif self.skin.strip() != "":
             skin = JAFilesystem.PathToFile(filepath, "")  + self.skin
         success, message = scene.saveToBlender(
             scale,
@@ -203,6 +205,7 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
         prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
         self.basepath = prefs.base_path
         self.scale = prefs.scale
+        print(self.skin)
         return super().invoke(context, event)
 
 

--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -25,6 +25,7 @@ from . import JAG2Scene
 from . import JAG2GLA
 from . import JAFilesystem
 from .JAG2Constants import SkeletonFixes
+from bpy_extras.io_utils import ImportHelper, ExportHelper
 
 
 def GetPaths(basepath, filepath) -> Tuple[str, str]:
@@ -36,7 +37,7 @@ def GetPaths(basepath, filepath) -> Tuple[str, str]:
     return basepath, filepath
 
 
-class GLMImport(bpy.types.Operator):
+class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
     '''Import GLM Operator.'''
     bl_idname = "import_scene.glm"
     bl_label = "Import JA Ghoul 2 Model (.glm)"
@@ -44,33 +45,65 @@ class GLMImport(bpy.types.Operator):
     # register is a must-have when using WindowManager.invoke_props_popup
     bl_options = {'REGISTER', 'UNDO'}
 
+    filename_ext = ".glm"
+    filter_glob: bpy.props.StringProperty(default="*.glm", options={'HIDDEN'})  # pyright: ignore [reportInvalidTypeForm]
+
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The .glm file to import", default="", subtype='FILE_PATH')  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path",
+        description="The .glm file to import",
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     skin: bpy.props.StringProperty(
-        name="Skin", description="The skin to load (modelname_<skin>.skin), leave empty to load none (use file internal paths)", default="default")  # pyright: ignore [reportInvalidTypeForm]
+        name="Skin",
+        description="The skin to load (modelname_<skin>.skin), leave empty to load none (use file internal paths)",
+        default="default")  # pyright: ignore [reportInvalidTypeForm]
     guessTextures: bpy.props.BoolProperty(
-        name="Guess Textures", description="Many models try to force you to use the skin. Enable this to try to circumvent that. (Usually works well, but skins should be preferred.)", default=False)  # pyright: ignore [reportInvalidTypeForm]
+        name="Guess Textures",
+        description="Many models try to force you to use the skin. Enable this to try to circumvent that. (Usually works well, but skins should be preferred.)",
+        default=False)  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
-        name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the importer guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="Base Path",
+        description="The base folder relative to which paths should be interpreted. Leave empty to let the importer guess (needs /GameData/ in filepath).",
+        default=""
+        )  # pyright: ignore [reportInvalidTypeForm]
     glaOverride: bpy.props.StringProperty(
-        name=".gla override", description="Gla file to use, relative to base. Leave empty to use the one referenced in the file.", maxlen=64, default="")  # pyright: ignore [reportInvalidTypeForm]
+        name=".gla override",
+        description="Gla file to use, relative to base. Leave empty to use the one referenced in the file.",
+        maxlen=64,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     scale: bpy.props.FloatProperty(
-        name="Scale", description="Scale to apply to the imported model.", default=10, min=0, max=1000, subtype='PERCENTAGE')  # pyright: ignore [reportInvalidTypeForm]
-    skeletonFixes: bpy.props.EnumProperty(name="skeleton changes", description="You can select a preset for automatic skeleton changes which result in a nicer imported skeleton.", default='NONE', items=[
+        name="Scale",
+        description="Scale to apply to the imported model.",
+        default=10,
+        min=0,
+        max=1000,
+        subtype='PERCENTAGE')  # pyright: ignore [reportInvalidTypeForm]
+    skeletonFixes: bpy.props.EnumProperty(
+        name="skeleton changes",
+        description="You can select a preset for automatic skeleton changes which result in a nicer imported skeleton.",
+        default='NONE',
+        items=[
         (SkeletonFixes.NONE.value, "None", "Don't change the skeleton in any way.", 0),
         (SkeletonFixes.JKA_HUMANOID.value, "Jedi Academy _humanoid",
          "Fixes for the default humanoid Jedi Academy skeleton", 1)
     ])  # pyright: ignore [reportInvalidTypeForm, reportArgumentType]
-    loadAnimations: bpy.props.EnumProperty(name="animations", description="Whether to import all animations, some animations or only a range from the .gla. (Importing huge animations takes forever.)", default='NONE', items=[
+    loadAnimations: bpy.props.EnumProperty(
+        name="animations",
+        description="Whether to import all animations, some animations or only a range from the .gla. (Importing huge animations takes forever.)",
+        default='NONE',
+        items=[
         (JAG2GLA.AnimationLoadMode.NONE.value, "None", "Don't import animations.", 0),
         (JAG2GLA.AnimationLoadMode.ALL.value, "All", "Import all animations", 1),
         (JAG2GLA.AnimationLoadMode.RANGE.value, "Range", "Import a certain range of frames", 2)
     ])  # pyright: ignore [reportInvalidTypeForm, reportArgumentType]
     startFrame: bpy.props.IntProperty(
-        name="Start frame", description="If only a range of frames of the animation is to be imported, this is the first.", min=0)  # pyright: ignore [reportInvalidTypeForm]
+        name="Start frame",
+        description="If only a range of frames of the animation is to be imported, this is the first.",
+        min=0)  # pyright: ignore [reportInvalidTypeForm]
     numFrames: bpy.props.IntProperty(
-        name="number of frames", description="If only a range of frames of the animation is to be imported, this is the total number of frames to import", min=1)  # pyright: ignore [reportInvalidTypeForm]
+        name="number of frames",
+        description="If only a range of frames of the animation is to be imported, this is the total number of frames to import",
+        min=1)  # pyright: ignore [reportInvalidTypeForm]
 
     def execute(self, context):
         print("\n== GLM Import ==\n")
@@ -103,48 +136,68 @@ class GLMImport(bpy.types.Operator):
         if self.skin != "":
             skin = filepath + "_" + self.skin
         success, message = scene.saveToBlender(
-            scale, skin, self.guessTextures, loadAnimations != JAG2GLA.AnimationLoadMode.NONE, SkeletonFixes[self.skeletonFixes])
+            scale,
+            skin,
+            self.guessTextures,
+            loadAnimations != JAG2GLA.AnimationLoadMode.NONE,
+            SkeletonFixes[self.skeletonFixes])
         if not success:
             self.report({'ERROR'}, message)
         return {'FINISHED'}
 
-    def invoke(self, context, event):  # pyright: ignore [reportIncompatibleMethodOverride]
-        # show file selection window
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
-
-class GLAImport(bpy.types.Operator):
+class GLAImport(bpy.types.Operator, ImportHelper): # type: ignore
     '''Import GLA Operator.'''
     bl_idname = "import_scene.gla"
     bl_label = "Import JA Ghoul 2 Skeleton (.gla)"
     bl_description = "Imports a Ghoul 2 skeleton (.gla) and optionally the animation."
     bl_options = {'REGISTER', 'UNDO'}
 
-    filename_ext = "*.gla"  # I believe this limits the shown files.
+    filename_ext = ".gla"  # I believe this limits the shown files.
+    filter_glob: bpy.props.StringProperty(default="*.gla", options={'HIDDEN'})  # pyright: ignore [reportInvalidTypeForm]
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The .gla file to import", maxlen=1024, default="", subtype='FILE_PATH')  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path",
+        description="The .gla file to import",
+        maxlen=1024,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
-        name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the importer guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="Base Path",
+        description="The base folder relative to which paths should be interpreted. Leave empty to let the importer guess (needs /GameData/ in filepath).",
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     scale: bpy.props.FloatProperty(
-        name="Scale", description="Scale to apply to the imported model.", default=10, min=0, max=1000, subtype='PERCENTAGE')  # pyright: ignore [reportInvalidTypeForm]
-    skeletonFixes: bpy.props.EnumProperty(name="skeleton changes", description="You can select a preset for automatic skeleton changes which result in a nicer imported skeleton.", default='NONE', items=[
+        name="Scale",
+        description="Scale to apply to the imported model.",
+        default=10,
+        min=0, 
+        max=1000,
+        subtype='PERCENTAGE')  # pyright: ignore [reportInvalidTypeForm]
+    skeletonFixes: bpy.props.EnumProperty(
+        name="skeleton changes",
+        description="You can select a preset for automatic skeleton changes which result in a nicer imported skeleton.",
+        default='NONE', items=[
         (SkeletonFixes.NONE.value, "None", "Don't change the skeleton in any way.", 0),
         (SkeletonFixes.JKA_HUMANOID.value, "Jedi Academy _humanoid",
          "Fixes for the default humanoid Jedi Academy skeleton", 1)
     ])  # pyright: ignore [reportInvalidTypeForm, reportArgumentType]
-    loadAnimations: bpy.props.EnumProperty(name="animations", description="Whether to import all animations, some animations or only a range from the .gla. (Importing huge animations takes forever.)", default='NONE', items=[
+    loadAnimations: bpy.props.EnumProperty(
+        name="animations",
+        description="Whether to import all animations, some animations or only a range from the .gla. (Importing huge animations takes forever.)",
+        default='NONE',
+        items=[
         (JAG2GLA.AnimationLoadMode.NONE.value, "None", "Don't import animations.", 0),
         (JAG2GLA.AnimationLoadMode.ALL.value, "All", "Import all animations", 1),
         (JAG2GLA.AnimationLoadMode.RANGE.value, "Range", "Import a certain range of frames", 2)
     ])  # pyright: ignore [reportInvalidTypeForm, reportArgumentType]
     startFrame: bpy.props.IntProperty(
-        name="Start frame", description="If only a range of frames of the animation is to be imported, this is the first.", min=0)  # pyright: ignore [reportInvalidTypeForm]
+        name="Start frame",
+        description="If only a range of frames of the animation is to be imported, this is the first.",
+        min=0)  # pyright: ignore [reportInvalidTypeForm]
     numFrames: bpy.props.IntProperty(
-        name="number of frames", description="If only a range of frames of the animation is to be imported, this is the total number of frames to import", min=1)  # pyright: ignore [reportInvalidTypeForm]
+        name="number of frames",
+        description="If only a range of frames of the animation is to be imported, this is the total number of frames to import",
+        min=1)  # pyright: ignore [reportInvalidTypeForm]
 
     def execute(self, context):
         print("\n== GLA Import ==\n")
@@ -170,24 +223,20 @@ class GLAImport(bpy.types.Operator):
             self.report({'ERROR'}, message)
         return {'FINISHED'}
 
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
-
-class GLMExport(bpy.types.Operator):
+class GLMExport(bpy.types.Operator, ExportHelper): # type: ignore
     '''Export GLM Operator.'''
     bl_idname = "export_scene.glm"
     bl_label = "Export JA Ghoul 2 Model (.glm)"
     bl_description = "Exports a Ghoul 2 model (.glm)"
     bl_options = {'REGISTER', 'UNDO'}
 
-    filename_ext = "*.glm"
+    filename_ext = ".glm"
+    filter_glob: bpy.props.StringProperty(default="*.glm", options={'HIDDEN'})  # pyright: ignore [reportInvalidTypeForm]
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The filename to export to", maxlen=1024, default="", subtype='FILE_PATH')  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path", description="The filename to export to", maxlen=1024, default="")  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
         name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
     gla: bpy.props.StringProperty(
@@ -212,24 +261,20 @@ class GLMExport(bpy.types.Operator):
             self.report({'ERROR'}, message)
         return {'FINISHED'}
 
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
-
-class GLAExport(bpy.types.Operator):
+class GLAExport(bpy.types.Operator, ExportHelper): # type: ignore
     '''Export GLA Operator.'''
     bl_idname = "export_scene.gla"
     bl_label = "Export JA Ghoul 2 Skeleton & Animation (.gla)"
     bl_description = "Exports a Ghoul 2 Skeleton and its animations (.gla)"
     bl_options = {'REGISTER', 'UNDO'}
 
-    filename_ext = "*.gla"
+    filename_ext = ".gla"
+    filter_glob: bpy.props.StringProperty(default="*.gla", options={'HIDDEN'})  # pyright: ignore [reportInvalidTypeForm]
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The filename to export to", maxlen=1024, default="", subtype='FILE_PATH')  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path", description="The filename to export to", maxlen=1024, default="")  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
         name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
     glapath: bpy.props.StringProperty(
@@ -262,11 +307,6 @@ class GLAExport(bpy.types.Operator):
         if not success:
             self.report({'ERROR'}, message)
         return {'FINISHED'}
-
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
 
 class ObjectAddG2Properties(bpy.types.Operator):
@@ -319,18 +359,22 @@ class ObjectRemoveG2Properties(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class GLAMetaExport(bpy.types.Operator):
+class GLAMetaExport(bpy.types.Operator, ExportHelper): # type: ignore
     '''Export GLA Metadata Operator.'''
     bl_idname = "export_scene.gla_meta"
     bl_label = "Export JA Ghoul 2 Animation metadata (.cfg)"
     bl_description = "Exports timeline markers labelling the animations to a .cfg file"
     bl_options = {'REGISTER', 'UNDO'}
 
-    filename_ext = "*.cfg"
+    filename_ext = ".cfg"
+    filter_glob: bpy.props.StringProperty(default="*.cfg", options={'HIDDEN'}) # pyright: ignore [reportInvalidTypeForm]
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The filename to export to", maxlen=1024, default="", subtype='FILE_PATH')  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path",
+        description="The filename to export to",
+        maxlen=1024,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     offset: bpy.props.IntProperty(
         name="Offset", description="Frame offset for the animations, e.g. 21376 if you plan on merging with Jedi Academy's _humanoid.gla", min=0, default=0)  # pyright: ignore [reportInvalidTypeForm]
 
@@ -385,10 +429,6 @@ class GLAMetaExport(bpy.types.Operator):
 
         return {'FINISHED'}
 
-    def invoke(self, context, event):
-        wm = context.window_manager
-        wm.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
 # menu button callback functions
 

--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -167,11 +167,6 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
         return {'FINISHED'}
     
     def draw(self, context):
-        addon_name = __name__.split('.')[0]
-        prefs = context.preferences.addons[addon_name].preferences
-        self.basepath = prefs.base_path
-        self.scale = prefs.scale
-
         layout = self.layout
         layout.use_property_split = True
         row = layout.row()
@@ -195,6 +190,12 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
             row.prop(self, "startFrame")
             row = layout.row()
             row.prop(self, "numFrames")
+
+    def invoke(self, context, event): # type: ignore
+        prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
+        self.basepath = prefs.base_path
+        self.scale = prefs.scale
+        return super().invoke(context, event)
 
 
 class GLAImport(bpy.types.Operator, ImportHelper): # type: ignore
@@ -276,13 +277,15 @@ class GLAImport(bpy.types.Operator, ImportHelper): # type: ignore
             self.report({'ERROR'}, message)
         return {'FINISHED'}
     
-    def draw(self, context):
-        addon_name = __name__.split('.')[0]
-        prefs = context.preferences.addons[addon_name].preferences
+    def invoke(self, context, event): # type: ignore
+        prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
         self.basepath = prefs.base_path
         self.scale = prefs.scale
-
+        return super().invoke(context, event)
+    
+    def draw(self, context):
         layout = self.layout
+        layout.use_property_split = True
         row = layout.row()
         row.prop(self, "basepath")
         row = layout.row()
@@ -310,9 +313,14 @@ class GLMExport(bpy.types.Operator, ExportHelper): # type: ignore
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The filename to export to", maxlen=1024, default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path",
+        description="The filename to export to",
+        maxlen=1024,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
-        name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="Base Path",
+        description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).",
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     gla: bpy.props.StringProperty(
         name=".gla name", description="Name of the skeleton this model uses (must exist!)", default="models/players/_humanoid/_humanoid")  # pyright: ignore [reportInvalidTypeForm]
 
@@ -335,16 +343,10 @@ class GLMExport(bpy.types.Operator, ExportHelper): # type: ignore
             self.report({'ERROR'}, message)
         return {'FINISHED'}
     
-    def draw(self, context):
-        addon_name = __name__.split('.')[0]
-        prefs = context.preferences.addons[addon_name].preferences
+    def invoke(self, context, event): # type: ignore
+        prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
         self.basepath = prefs.base_path
-
-        layout = self.layout
-        row = layout.row()
-        row.prop(self, "basepath")
-        row = layout.row()
-        row.prop(self, "gla")
+        return super().invoke(context, event)
 
 
 class GLAExport(bpy.types.Operator, ExportHelper): # type: ignore
@@ -359,13 +361,24 @@ class GLAExport(bpy.types.Operator, ExportHelper): # type: ignore
 
     # properties
     filepath: bpy.props.StringProperty(
-        name="File Path", description="The filename to export to", maxlen=1024, default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="File Path",
+        description="The filename to export to",
+        maxlen=1024,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     basepath: bpy.props.StringProperty(
-        name="Base Path", description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).", default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="Base Path",
+        description="The base folder relative to which paths should be interpreted. Leave empty to let the exporter guess (needs /GameData/ in filepath).",
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     glapath: bpy.props.StringProperty(
-        name="gla name", description="The relative path of this gla. Leave empty to let the exporter guess (needs /GameData/ in filepath).", maxlen=64, default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="gla name",
+        description="The relative path of this gla. Leave empty to let the exporter guess (needs /GameData/ in filepath).",
+        maxlen=64,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
     glareference: bpy.props.StringProperty(
-        name="gla reference", description="Copies the bone indices from this skeleton, if any (e.g. for new animations for existing skeleton; path relative to the Base Path)", maxlen=64, default="")  # pyright: ignore [reportInvalidTypeForm]
+        name="gla reference",
+        description="Copies the bone indices from this skeleton, if any (e.g. for new animations for existing skeleton; path relative to the Base Path)",
+        maxlen=64,
+        default="")  # pyright: ignore [reportInvalidTypeForm]
 
     def execute(self, context):
         print("\n== GLA Export ==\n")
@@ -393,18 +406,10 @@ class GLAExport(bpy.types.Operator, ExportHelper): # type: ignore
             self.report({'ERROR'}, message)
         return {'FINISHED'}
     
-    def draw(self, context):
-        addon_name = __name__.split('.')[0]
-        prefs = context.preferences.addons[addon_name].preferences
+    def invoke(self, context, event): # type: ignore
+        prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
         self.basepath = prefs.base_path
-
-        layout = self.layout
-        row = layout.row()
-        row.prop(self, "basepath")
-        row = layout.row()
-        row.prop(self, "glapath")
-        row = layout.row()
-        row.prop(self, "glareference")
+        return super().invoke(context, event)
 
 
 class ObjectAddG2Properties(bpy.types.Operator):
@@ -474,7 +479,10 @@ class GLAMetaExport(bpy.types.Operator, ExportHelper): # type: ignore
         maxlen=1024,
         default="")  # pyright: ignore [reportInvalidTypeForm]
     offset: bpy.props.IntProperty(
-        name="Offset", description="Frame offset for the animations, e.g. 21376 if you plan on merging with Jedi Academy's _humanoid.gla", min=0, default=0)  # pyright: ignore [reportInvalidTypeForm]
+        name="Offset",
+        description="Frame offset for the animations, e.g. 21376 if you plan on merging with Jedi Academy's _humanoid.gla",
+        min=0,
+        default=0)  # pyright: ignore [reportInvalidTypeForm]
 
     def execute(self, context):
         print("\n== GLA Metadata Export ==\n")

--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -205,7 +205,6 @@ class GLMImport(bpy.types.Operator, ImportHelper): # type: ignore
         prefs = bpy.context.preferences.addons[__name__.split('.')[0]].preferences
         self.basepath = prefs.base_path
         self.scale = prefs.scale
-        print(self.skin)
         return super().invoke(context, event)
 
 

--- a/JAG2Panels.py
+++ b/JAG2Panels.py
@@ -14,15 +14,21 @@ def hasG2ArmatureProperties(obj: bpy.types.Object) -> bool:
 def initG2Properties() -> None:
     """ globally initializes the ghoul 2 custom properties """
     bpy.types.Object.g2_prop_name = bpy.props.StringProperty(
-        name="name", maxlen=64, default="", description="Name (in case it doesn't fit in Blender's Object Name, which is used if this is empty.)")
+        name="name", maxlen=64, default="", description="Name (in case it doesn't fit in Blender's Object Name, which is used if this is empty)")
     bpy.types.Object.g2_prop_shader = bpy.props.StringProperty(
         name="shader", maxlen=64, default="", description="Shader to use (the one and only way to set this)")
     bpy.types.Object.g2_prop_tag = bpy.props.BoolProperty(
-        name="Tag", default=False, description="Whether this object represents a tag.")
+        name="Tag", default=False, description="Whether this object represents a tag")
     bpy.types.Object.g2_prop_off = bpy.props.BoolProperty(
-        name="Off", default=False, description="Whether this object should be initially off (can be overridden in skin).")
+        name="Off", default=False, description="Whether this object should be initially off (can be overridden in skin)")
     bpy.types.Object.g2_prop_scale = bpy.props.FloatProperty(
-        name="Scale", default=100, min=0, subtype='PERCENTAGE', description="Scale of this skeleton.")
+        name="Scale", default=100, min=0, subtype='PERCENTAGE', description="Scale of this skeleton")
+    
+def initSeqenceProperties() -> None:
+    bpy.types.Action.loop_frame = bpy.props.BoolProperty(
+        name="Loop", default=False, description="Whether this squence will loop")
+    bpy.types.Action.fps = bpy.props.IntProperty(
+        name="FPS", default=30, description="Sequence playback fps")
 
 
 class G2PropertiesPanel(bpy.types.Panel):
@@ -69,3 +75,42 @@ class G2PropertiesPanel(bpy.types.Panel):
             else:
                 row = layout.row()
                 row.operator("object.add_g2_properties")
+
+class G2NLAPropertiesPanel(bpy.types.Panel):
+    bl_label = "GLA Animation Properties"
+    bl_idname = "STRIP_PT_g2sequence_props"
+    bl_space_type = 'NLA_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(self, context):
+        return context.active_nla_strip and context.active_nla_strip.action is not None
+    
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        row = layout.row()
+        row.prop(context.active_nla_strip.action, "loop_frame")
+        row = layout.row()
+        row.prop(context.active_nla_strip.action, "fps")
+
+
+class G2ActionPropertiesPanel(bpy.types.Panel):
+    bl_label = "GLA Animation Properties"
+    bl_idname = "ACTION_PT_g2sequence_props"
+    bl_space_type = 'DOPESHEET_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = "Action"
+
+    @classmethod
+    def poll(self, context):
+        return context.active_action is not None
+    
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        row = layout.row()
+        row.prop(context.active_action, "loop_frame")
+        row = layout.row()
+        row.prop(context.active_action, "fps")

--- a/JARoffImport.py
+++ b/JARoffImport.py
@@ -52,7 +52,6 @@ class Operator(bpy.types.Operator):
             scn = bpy.context.scene
             scn.frame_start = 0
             scn.frame_end = frames
-            scn.frame_current = 0
             scn.render.fps = 1000/frameDuration  # supposedly read-only?
 
             # add keyframe at frame 0 with current position
@@ -62,7 +61,6 @@ class Operator(bpy.types.Operator):
 
             for frame in range(frames):
                 # set the current frame
-                scn.frame_current = frame + 1
                 # I don't know what the last 8 bytes are, they always contain 0xFFFFFFFF00000000 (-1 & 0) - I trash them.
                 dx, dy, dz, droty, drotz, drotx = struct.unpack(
                     "6f8x", file.read(32))
@@ -82,11 +80,9 @@ class Operator(bpy.types.Operator):
                     math.radians(drotz)
 
                 # save keyframe
-                obj.keyframe_insert("location")
-                obj.keyframe_insert("rotation_euler")
+                obj.keyframe_insert("location", frame=frame + 1)
+                obj.keyframe_insert("rotation_euler", frame=frame + 1)
 
-            # back to frame 0
-            scn.frame_current = 0
             # set the interpolation to linear
             for curve in obj.animation_data.action.fcurves:
                 for point in curve.keyframe_points:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PY_FILES = __init__.py mod_reload.py casts.py error_types.py JAAseExport.py JAAseImport.py JAFilesystem.py JAG2Constants.py JAG2GLA.py JAG2GLM.py JAG2Math.py JAG2Operators.py JAG2Panels.py JAG2Scene.py JAMaterialmanager.py JAMd3Encode.py JAMd3Export.py JAPatchExport.py JARoffExport.py JARoffImport.py JAStringhelper.py MrwProfiler.py
+PY_FILES = __init__.py mod_reload.py casts.py error_types.py JAAseExport.py JAAseImport.py JAFilesystem.py JAG2AnimationCFG.py JAG2Constants.py JAG2GLA.py JAG2GLM.py JAG2Math.py JAG2Operators.py JAG2Panels.py JAG2Scene.py JAMaterialmanager.py JAMd3Encode.py JAMd3Export.py JAPatchExport.py JARoffExport.py JARoffImport.py JAStringhelper.py MrwProfiler.py
 
 ZIP_CONTENTS = $(PY_FILES) jediacademy_plugins_readme.txt
 

--- a/__init__.py
+++ b/__init__.py
@@ -50,7 +50,34 @@ bl_info = {
 JAAseExportOp = JAAseExport.Operator
 
 
+class JAAddonPreferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
+    base_path: bpy.props.StringProperty(
+        name="default base path",
+        description="Path to base folder",
+        default="",
+        subtype="DIR_PATH",
+        maxlen=2048,
+    ) # pyright: ignore [reportInvalidTypeForm]
+
+    scale: bpy.props.FloatProperty(
+        name="default import scale",
+        description="Scale of imported objects in percent",
+        default=10,
+        min = 0,
+        max = 1000
+    ) # pyright: ignore [reportInvalidTypeForm]
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.prop(self, "base_path")
+        row = layout.row()
+        row.prop(self, "scale")
+
+
 def register():
+    bpy.utils.register_class(JAAddonPreferences)
     bpy.utils.register_class(JAAseExport.Operator)
     bpy.utils.register_class(JAPatchExport.Operator)
     bpy.utils.register_class(JARoffExport.Operator)
@@ -76,6 +103,7 @@ def unregister():
     bpy.utils.unregister_class(JAAseImport.Operator)
     bpy.utils.unregister_class(JARoffImport.Operator)
     bpy.utils.unregister_class(JAG2Panels.G2PropertiesPanel)
+    bpy.utils.unregister_class(JAAddonPreferences)
 
     JAG2Operators.unregister()
 

--- a/__init__.py
+++ b/__init__.py
@@ -70,6 +70,7 @@ class JAAddonPreferences(bpy.types.AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
+        layout.use_property_split = True
         row = layout.row()
         row.prop(self, "base_path")
         row = layout.row()

--- a/__init__.py
+++ b/__init__.py
@@ -85,8 +85,11 @@ def register():
     bpy.utils.register_class(JAAseImport.Operator)
     bpy.utils.register_class(JARoffImport.Operator)
     bpy.utils.register_class(JAG2Panels.G2PropertiesPanel)
+    bpy.utils.register_class(JAG2Panels.G2NLAPropertiesPanel)
+    bpy.utils.register_class(JAG2Panels.G2ActionPropertiesPanel)
 
     JAG2Panels.initG2Properties()
+    JAG2Panels.initSeqenceProperties()
     JAG2Operators.register()
 
     bpy.types.TOPBAR_MT_file_export.append(JAAseExport.menu_func)
@@ -104,6 +107,8 @@ def unregister():
     bpy.utils.unregister_class(JAAseImport.Operator)
     bpy.utils.unregister_class(JARoffImport.Operator)
     bpy.utils.unregister_class(JAG2Panels.G2PropertiesPanel)
+    bpy.utils.unregister_class(JAG2Panels.G2NLAPropertiesPanel)
+    bpy.utils.unregister_class(JAG2Panels.G2ActionPropertiesPanel)
     bpy.utils.unregister_class(JAAddonPreferences)
 
     JAG2Operators.unregister()


### PR DESCRIPTION
Besides skipping changing between object and pose mode to force matrix updates, we also set keyframes outside of the transform loop.
It also doesnt change the scene frame anymore (no measurable performance gains though)

With the updated code I can import all rancor animation frames in round about 6 and a half minutes on my machine at no visual difference to the animations. Before it took nealy 40 minutes to import all these frames.

- Fixes https://github.com/mrwonko/Blender-Jedi-Academy-Tools/issues/56 and fixes https://github.com/mrwonko/Blender-Jedi-Academy-Tools/issues/39
- Fixes https://github.com/mrwonko/Blender-Jedi-Academy-Tools/issues/55
- Fixes https://github.com/mrwonko/Blender-Jedi-Academy-Tools/issues/53
- Fixes https://github.com/mrwonko/Blender-Jedi-Academy-Tools/issues/44
