### PR TITLE
Don't auto-connect a bone if that would clip real translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs/
 __pycache__/
 build/
+.proprietary/

--- a/JAG2Constants.py
+++ b/JAG2Constants.py
@@ -41,11 +41,20 @@ BONELENGTH = 4
 # cosine of allowed angle between bone directions for them to be considered equal
 BONE_ANGLE_ERROR_MARGIN = 0.996
 
+# CompBone's compressed frame translation is quantized to this many steps per unit (see
+# JAG2Math.CompBone.loadFromFile/compress) - the smallest movement a compressed frame can
+# represent along a single axis.
+COMPBONE_LOCATION_STEPS_PER_UNIT = 64
+COMPBONE_LOCATION_QUANTUM = 1 / COMPBONE_LOCATION_STEPS_PER_UNIT
+
 # max distance (game units) a bone's actual per-frame head position may drift from where a
 # rigidly-connected bone's head would be (the parent's tail, following the parent's rotation)
 # before we consider it to need independent translation - use_connect can't represent that.
-# Accounts for float/quantization noise in the chained matrix math, not a real design tolerance.
-BONE_TRANSLATION_ERROR_MARGIN = 0.05
+# _boneCanConnect compares positions reconstructed from compressed (quantized) frame data through
+# a chain of ancestor transforms, so quantization/floating-point noise can compound across the
+# hierarchy - a few quantization steps of wiggle room comfortably covers that without masking a
+# real, consistently-drifting translation.
+BONE_TRANSLATION_ERROR_MARGIN = 3 * COMPBONE_LOCATION_QUANTUM
 
 
 class SkeletonFixes(Enum):

--- a/JAG2Constants.py
+++ b/JAG2Constants.py
@@ -41,6 +41,12 @@ BONELENGTH = 4
 # cosine of allowed angle between bone directions for them to be considered equal
 BONE_ANGLE_ERROR_MARGIN = 0.996
 
+# max distance (game units) a bone's actual per-frame head position may drift from where a
+# rigidly-connected bone's head would be (the parent's tail, following the parent's rotation)
+# before we consider it to need independent translation - use_connect can't represent that.
+# Accounts for float/quantization noise in the chained matrix math, not a real design tolerance.
+BONE_TRANSLATION_ERROR_MARGIN = 0.05
+
 
 class SkeletonFixes(Enum):
     NONE = 'NONE'

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -112,10 +112,10 @@ def _boneCanConnect(transformsPerFrame: List[Dict[int, "mathutils.Matrix"]], all
     parentBase = allBones[parentIndex].basePoseMat.toBlender()
     JAG2Math.GLABoneRotToBlender(childBase)
     JAG2Math.GLABoneRotToBlender(parentBase)
-    restRelativeHead = vector_overload_cast(parentBase.inverted() @ mathutils.Vector(childBase.translation))
+    restRelativeHead = vector_overload_cast(parentBase.inverted() @ mathutils.Vector(childBase.translation))  # pyright: ignore [reportArgumentType]  # vector supports slices
     for transforms in transformsPerFrame:
         parentTransform = transforms[parentIndex]
-        childHead = mathutils.Vector(transforms[boneIndex].translation)
+        childHead = mathutils.Vector(transforms[boneIndex].translation)  # pyright: ignore [reportArgumentType]  # vector supports slices
         relativeHead = vector_overload_cast(parentTransform.inverted() @ childHead)
         if (relativeHead - restRelativeHead).length > JAG2Constants.BONE_TRANSLATION_ERROR_MARGIN:
             return False

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -223,19 +223,20 @@ class MdxaBone:
 
             # if this is the only child of its parent or has priority: Connect the parent to this.
             if numParentChildren == 1 or self.name in JAG2Constants.PRIORITY_BONES[skeletonFixes]:
-                # but only if the animation doesn't need this bone to translate independently of
-                # its parent - use_connect rigidly locks the head to the parent's tail, which would
-                # silently clip such translation on reimport.
-                if _boneCanConnect(transformsPerFrame, allBones, self.index, parentIndex):
-                    # but only if that doesn't rotate the bone (much)
-                    # so calculate the directions...
-                    oldDir = vector_getter_cast(blenderParent.tail) - vector_getter_cast(blenderParent.head)
-                    newDir = pos - blenderParent.head
-                    oldDir.normalize()
-                    newDir.normalize()
-                    dotProduct = oldDir.dot(newDir)
-                    # ... and compare them using the dot product, which is the cosine of the angle between two unit vectors
-                    if dotProduct > JAG2Constants.BONE_ANGLE_ERROR_MARGIN:
+                # but only if that doesn't rotate the bone (much) - check this first since it's
+                # much cheaper than _boneCanConnect below (which loops over every frame)
+                # so calculate the directions...
+                oldDir = vector_getter_cast(blenderParent.tail) - vector_getter_cast(blenderParent.head)
+                newDir = pos - blenderParent.head
+                oldDir.normalize()
+                newDir.normalize()
+                dotProduct = oldDir.dot(newDir)
+                # ... and compare them using the dot product, which is the cosine of the angle between two unit vectors
+                if dotProduct > JAG2Constants.BONE_ANGLE_ERROR_MARGIN:
+                    # and only if the animation doesn't need this bone to translate independently
+                    # of its parent - use_connect rigidly locks the head to the parent's tail,
+                    # which would silently clip such translation on reimport.
+                    if _boneCanConnect(transformsPerFrame, allBones, self.index, parentIndex):
                         blenderParent.tail = pos
                         bone.use_connect = True
 
@@ -435,6 +436,11 @@ class MdxaAnimation:
     # via the same forward-kinematics math applied to actual Blender pose bones in saveToBlender
     # below - but pure Python, so it can run before any Blender armature exists (used to decide
     # auto-connect behavior ahead of bone creation, see MdxaBone.saveToBlender/_boneCanConnect).
+    # Memory: measured against real production skeletons (headless Blender, resource.getrusage
+    # RSS) - _humanoid-ja.gla (53 bones, 21376 frames) costs ~193MB for the returned structure,
+    # _humanoid-jk2.gla (72 bones, 17278 frames) ~196MB - both well under 1GB, and it's transient:
+    # the caller (MdxaSkel.saveToBlender) only keeps this in a local variable for the duration of
+    # bone creation, not for the lifetime of the import.
     def computeAbsoluteFrameTransforms(self, skeleton: MdxaSkel) -> List[Dict[int, mathutils.Matrix]]:
         if not self.frames:
             return []

--- a/JAG2GLA.py
+++ b/JAG2GLA.py
@@ -23,7 +23,7 @@ from . import JAStringhelper
 from . import JAG2Constants
 from . import JAG2Math
 from . import MrwProfiler
-from .casts import optional_cast, downcast, bpy_generic_cast, matrix_getter_cast, matrix_overload_cast, vector_getter_cast
+from .casts import optional_cast, downcast, bpy_generic_cast, matrix_getter_cast, matrix_overload_cast, vector_getter_cast, vector_overload_cast
 from .error_types import ErrorMessage, NoError, ensureListIsGapless
 
 from typing import BinaryIO, Dict, List, Optional, Tuple
@@ -95,6 +95,33 @@ class MdxaBoneOffsets:
 # originally called MdxaSkel_t, but I find that name misleading
 
 
+# whether auto-connecting boneIndex to parentIndex would faithfully reproduce its animation: a
+# connected bone is rigidly attached to its parent - its head, expressed in the parent's own
+# current local frame, never moves from where it sits at rest; only its own rotation can vary.
+# So this checks whether the bone's head, re-expressed in the parent's frame each frame, ever
+# drifts from that bind-pose-relative position. If it does, the bone needs independent
+# translation that use_connect can't represent. transformsPerFrame is
+# MdxaAnimation.computeAbsoluteFrameTransforms's output; an empty list (no animation data
+# available) means there's nothing to check against, so it's fine to connect.
+def _boneCanConnect(transformsPerFrame: List[Dict[int, "mathutils.Matrix"]], allBones: List["MdxaBone"], boneIndex: int, parentIndex: int) -> bool:
+    # rest pose is just the frame where the compressed offset is identity, so put it through the
+    # same GLABoneRotToBlender conversion computeAbsoluteFrameTransforms applies to every other
+    # frame's combined (offset @ basePoseMat) - otherwise the two are in different coordinate
+    # conventions and every comparison shows a large constant offset instead of a real signal.
+    childBase = allBones[boneIndex].basePoseMat.toBlender()
+    parentBase = allBones[parentIndex].basePoseMat.toBlender()
+    JAG2Math.GLABoneRotToBlender(childBase)
+    JAG2Math.GLABoneRotToBlender(parentBase)
+    restRelativeHead = vector_overload_cast(parentBase.inverted() @ mathutils.Vector(childBase.translation))
+    for transforms in transformsPerFrame:
+        parentTransform = transforms[parentIndex]
+        childHead = mathutils.Vector(transforms[boneIndex].translation)
+        relativeHead = vector_overload_cast(parentTransform.inverted() @ childHead)
+        if (relativeHead - restRelativeHead).length > JAG2Constants.BONE_TRANSLATION_ERROR_MARGIN:
+            return False
+    return True
+
+
 class MdxaBone:
     def __init__(self):
         self.name = ""
@@ -154,7 +181,7 @@ class MdxaBone:
     # blenderBonesSoFar is a dictionary of boneIndex -> BlenderBone
     # allBones is the list of all MdxaBones
     # use it to set up hierarchy and add yourself once done.
-    def saveToBlender(self, armature: bpy.types.Armature, blenderBonesSoFar: Dict[int, bpy.types.EditBone], allBones: List["MdxaBone"], skeletonFixes: JAG2Constants.SkeletonFixes) -> None:
+    def saveToBlender(self, armature: bpy.types.Armature, blenderBonesSoFar: Dict[int, bpy.types.EditBone], allBones: List["MdxaBone"], skeletonFixes: JAG2Constants.SkeletonFixes, transformsPerFrame: List[Dict[int, "mathutils.Matrix"]]) -> None:
         # create bone
         bone = armature.edit_bones.new(self.name)
 
@@ -196,17 +223,21 @@ class MdxaBone:
 
             # if this is the only child of its parent or has priority: Connect the parent to this.
             if numParentChildren == 1 or self.name in JAG2Constants.PRIORITY_BONES[skeletonFixes]:
-                # but only if that doesn't rotate the bone (much)
-                # so calculate the directions...
-                oldDir = vector_getter_cast(blenderParent.tail) - vector_getter_cast(blenderParent.head)
-                newDir = pos - blenderParent.head
-                oldDir.normalize()
-                newDir.normalize()
-                dotProduct = oldDir.dot(newDir)
-                # ... and compare them using the dot product, which is the cosine of the angle between two unit vectors
-                if dotProduct > JAG2Constants.BONE_ANGLE_ERROR_MARGIN:
-                    blenderParent.tail = pos
-                    bone.use_connect = True
+                # but only if the animation doesn't need this bone to translate independently of
+                # its parent - use_connect rigidly locks the head to the parent's tail, which would
+                # silently clip such translation on reimport.
+                if _boneCanConnect(transformsPerFrame, allBones, self.index, parentIndex):
+                    # but only if that doesn't rotate the bone (much)
+                    # so calculate the directions...
+                    oldDir = vector_getter_cast(blenderParent.tail) - vector_getter_cast(blenderParent.head)
+                    newDir = pos - blenderParent.head
+                    oldDir.normalize()
+                    newDir.normalize()
+                    dotProduct = oldDir.dot(newDir)
+                    # ... and compare them using the dot product, which is the cosine of the angle between two unit vectors
+                    if dotProduct > JAG2Constants.BONE_ANGLE_ERROR_MARGIN:
+                        blenderParent.tail = pos
+                        bone.use_connect = True
 
         # save to created bones
         blenderBonesSoFar[self.index] = bone
@@ -237,7 +268,11 @@ class MdxaSkel:
                 return False, ErrorMessage(f"Bone {bone.name} not found in existing skeleton_root armature!")
         return True, NoError
 
-    def saveToBlender(self, scene_root: bpy.types.Object, skeletonFixes: JAG2Constants.SkeletonFixes) -> Tuple[bool, ErrorMessage]:
+    def saveToBlender(self, scene_root: bpy.types.Object, skeletonFixes: JAG2Constants.SkeletonFixes, animation: Optional["MdxaAnimation"] = None) -> Tuple[bool, ErrorMessage]:
+        # computed once up front (not per-bone) since it doesn't depend on Blender bone state -
+        # see MdxaBone.saveToBlender/_boneCanConnect for why it's needed.
+        transformsPerFrame = animation.computeAbsoluteFrameTransforms(self) if animation is not None else []
+
         #  Creation
         # create armature
         self.armature = bpy.data.armatures.new("skeleton_root")
@@ -271,7 +306,7 @@ class MdxaSkel:
                     parent = bone.parent
                 if parent in createdBonesIndices:
                     bone.saveToBlender(
-                        self.armature, blenderEditBones, self.bones, skeletonFixes)
+                        self.armature, blenderEditBones, self.bones, skeletonFixes, transformsPerFrame)
                     createdBonesIndices.append(bone.index)
                     createdBone = True
                 else:
@@ -380,6 +415,48 @@ class MdxaAnimation:
                 "Info: .gla Bone Pool read but file not over yet - this likely indicates a problem.")
         return True, NoError
 
+    # bones in parent-first order - shared by saveToBlender and computeAbsoluteFrameTransforms.
+    @staticmethod
+    def _hierarchyOrder(skeleton: MdxaSkel) -> List[int]:
+        hierarchyOrder: List[int] = []
+        while len(hierarchyOrder) < len(skeleton.bones):
+            addedSomething = False
+            for bone in skeleton.bones:
+                if bone.index in hierarchyOrder:
+                    continue
+                if bone.parent != -1 and bone.parent not in hierarchyOrder:
+                    continue
+                hierarchyOrder.append(bone.index)
+                addedSomething = True
+            assert (addedSomething)
+        return hierarchyOrder
+
+    # for each frame, each bone's absolute (armature-space, Blender-convention) posed transform,
+    # via the same forward-kinematics math applied to actual Blender pose bones in saveToBlender
+    # below - but pure Python, so it can run before any Blender armature exists (used to decide
+    # auto-connect behavior ahead of bone creation, see MdxaBone.saveToBlender/_boneCanConnect).
+    def computeAbsoluteFrameTransforms(self, skeleton: MdxaSkel) -> List[Dict[int, mathutils.Matrix]]:
+        if not self.frames:
+            return []
+        hierarchyOrder = self._hierarchyOrder(skeleton)
+        basePoses = [bone.basePoseMat.toBlender() for bone in skeleton.bones]
+        compBones = downcast(List[JAG2Math.CompBone], self.bonePool.bones)
+        result: List[Dict[int, mathutils.Matrix]] = []
+        for frame in self.frames:
+            absoluteOffsets: Dict[int, mathutils.Matrix] = {}
+            transforms: Dict[int, mathutils.Matrix] = {}
+            for index in hierarchyOrder:
+                bone = skeleton.bones[index]
+                offset = compBones[frame.boneIndices[index]].matrix
+                if bone.parent != -1:
+                    offset = matrix_overload_cast(absoluteOffsets[bone.parent] @ offset)
+                absoluteOffsets[index] = offset
+                transformation = matrix_overload_cast(offset @ basePoses[index])
+                JAG2Math.GLABoneRotToBlender(transformation)
+                transforms[index] = transformation
+            result.append(transforms)
+        return result
+
     def saveToFile(self, file: BinaryIO, header: MdxaHeader):
         assert (file.tell() == header.ofsFrames)
         for frame in self.frames:
@@ -397,20 +474,7 @@ class MdxaAnimation:
         #   Bone Position Set Order
         # bones have to be set in hierarchical order - their position depends on their parent's absolute position, after all.
         # so this is the order in which bones have to be processed.
-        hierarchyOrder: List[int] = []
-        while len(hierarchyOrder) < len(skeleton.bones):
-            # make sure we add something each frame (infinite loop otherwise)
-            addedSomething = False
-            # I could copy skeleton.bones for minor speed boost, imho not necessary.
-            for bone in skeleton.bones:
-                if bone.index in hierarchyOrder:
-                    continue  # we already have this one.
-                if bone.parent != -1 and bone.parent not in hierarchyOrder:
-                    # we don't have the parent yet, so this cannot come yet.
-                    continue
-                hierarchyOrder.append(bone.index)
-                addedSomething = True
-            assert (addedSomething)
+        hierarchyOrder = self._hierarchyOrder(skeleton)
         # for going leaf to root
 
         #   Blender PoseBones list
@@ -832,7 +896,7 @@ class GLA:
         # create armature
         profiler.start("creating armature")
         success, message = self.skeleton.saveToBlender(
-            scene_root, skeletonFixes)
+            scene_root, skeletonFixes, self.animation)
         if not success:
             return False, message
         self.skeleton_armature = self.skeleton.armature

--- a/JAG2Math.py
+++ b/JAG2Math.py
@@ -16,6 +16,11 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+from .mod_reload import reload_modules
+reload_modules(locals(), __package__, ["JAG2Constants"], [])  # nopep8
+
+from . import JAG2Constants
+
 import struct
 from typing import BinaryIO
 import mathutils
@@ -109,9 +114,9 @@ class CompBone:
         quat.y = (q_y / 16383) - 2
         quat.z = (q_z / 16383) - 2
         # map location from 0..65535 to -512..512 (511.984375)
-        loc.x = (l_x / 64) - 512
-        loc.y = (l_y / 64) - 512
-        loc.z = (l_z / 64) - 512
+        loc.x = (l_x / JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT) - 512
+        loc.y = (l_y / JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT) - 512
+        loc.z = (l_z / JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT) - 512
 
         # turn rotation into matrix
         matrix = quat.to_matrix()
@@ -136,6 +141,6 @@ class CompBone:
                            round((quat.x + 2) * 16383),
                            round((quat.y + 2) * 16383),
                            round((quat.z + 2) * 16383),
-                           round((loc.x + 512) * 64),
-                           round((loc.y + 512) * 64),
-                           round((loc.z + 512) * 64))
+                           round((loc.x + 512) * JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT),
+                           round((loc.y + 512) * JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT),
+                           round((loc.z + 512) * JAG2Constants.COMPBONE_LOCATION_STEPS_PER_UNIT))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -116,21 +116,7 @@ def case_roundtrip():
     expected_glm = _load_glm(REFERENCE_BASEPATH)
     expected_gla = _load_gla(REFERENCE_BASEPATH)
 
-    gla_mismatches = testutil.compare_gla(actual_gla, expected_gla)
-
-    # KNOWN ISSUE, not yet fixed - tracked separately, not blocking CI:
-    # MdxaBone.saveToBlender auto-connects a bone to its parent whenever it's the
-    # parent's only child (regardless of skeletonFixes), which silently overrides a
-    # deliberately-disabled use_connect from the original authoring file. A connected
-    # bone can't translate independently of its parent's tail in Blender, so any
-    # animation asking it to do so (like Bone.002 here, from frame 11 on) gets dropped
-    # on reimport. Log it, but don't fail the suite on it until the heuristic is fixed.
-    known_issue = [m for m in gla_mismatches if "bone 'Bone.002'" in m]
-    other_gla_mismatches = [m for m in gla_mismatches if m not in known_issue]
-    for m in known_issue:
-        print(f"[test] KNOWN ISSUE (not failing): {m}")
-
-    testutil.check(testutil.compare_glm(actual_glm, expected_glm) + other_gla_mismatches)
+    testutil.check(testutil.compare_glm(actual_glm, expected_glm) + testutil.compare_gla(actual_gla, expected_gla))
 
 
 runner = testutil.TestRunner()


### PR DESCRIPTION
## Summary

`MdxaBone.saveToBlender`'s auto-connect heuristic (`use_connect = True`) rigidly locks a bone's head to its parent's tail. It runs unconditionally for any only-child bone (or priority bone) whose rest-pose direction from the parent doesn't change much, regardless of what the bone's animation needs. Confirmed via the headless test suite's roundtrip case (`tests/testdata/.../simpleskel.gla`, bones `Bone` → `Bone.001` → `Bone.002`): the original authoring `.blend` had `use_connect` deliberately disabled on `Bone.002` to allow it to translate independently starting frame 11, but reimporting silently re-enables it, clipping that translation every time.

## The fix

Checks each bone's actual per-frame head position — via the same forward-kinematics math `MdxaAnimation.saveToBlender` already uses to pose real Blender bones, computed in pure Python before any armature exists — against where a rigidly-connected head would sit, expressed in the parent's own current local frame. Only skips connecting when that position genuinely drifts. Pure rotation, even of a bone whose rest position isn't at the coordinate origin, doesn't move the attachment point and still connects fine (verified: `Bone.001`, which only ever rotates in the source `.blend`, correctly stays connected).

Two earlier approaches were tried and ruled out empirically before landing on this one (see the commit message for details) — worth a mention since both looked plausible until checked against real data:
1. Checking the file's stored relative-offset translation directly — wrong, because that representation always has a translation-shaped term for bones whose rest position isn't at the origin, regardless of real motion (a geometric artifact of the parent-relative matrix math, not real translation).
2. A tail/`BONELENGTH`-based version of the current check — wrong, because a parent's edit-mode tail can be overwritten by its own connect decision, and it also compared across mismatched GLA/Blender coordinate conventions.

Also removes `tests/run_tests.py`'s now-stale "known issue, don't fail" carve-out for this exact bug, so a future regression here gets caught instead of silently logged.

## Test plan

- [x] Full headless suite (`tests/run_tests.py`) passes locally via podman: `smoke`, `export`, `roundtrip` all PASS, `roundtrip` with zero mismatches (previously had known-issue lines for this exact bug).
- [x] Surgical confirmation via the real armature-creation path: `Bone` (root) → `use_connect=False` (unaffected), `Bone.001` (rotation only) → `use_connect=True` (correctly still connects), `Bone.002` (real translation from frame 11) → `use_connect=False` (correctly no longer connects).
- [x] CI (`.github/workflows/test.yml`) will run the same suite on push — should also go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6RHzeSdbxz1afiWXX2Tve