### PR TITLE
Add pyright typecheck job to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,13 @@ jobs:
 
       - name: Run test suite in headless Blender
         run: /home/headless/blender/blender --background --python-exit-code 1 --python tests/run_tests.py
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install pyright fake-bpy-module-4.5
+      - run: pyright --pythonpath "$(command -v python3)"


### PR DESCRIPTION
## Summary
Depends on #90 (pyright-cleanup) - targets that branch rather than `headless-tests` since this only makes sense once the repo is actually pyright-clean; retarget to `headless-tests` once #90 merges.

- Adds a `typecheck` job to `.github/workflows/test.yml`, running alongside the existing headless Blender smoke/export/roundtrip job. Plain `ubuntu-latest`, no Blender container needed.
- Installs `pyright` + `fake-bpy-module-4.5` via pip, then runs `pyright --pythonpath "$(command -v python3)"` against the repo's `pyrightconfig.json` (added in #90).
- The explicit `--pythonpath` is required: pyright doesn't auto-detect the invoking interpreter's installed packages, so without it `bpy`/`mathutils` resolve as missing imports even with the stubs installed. Verified locally by installing into a `.venv` and running the exact same command via `PATH`.

## Test plan
- [x] Locally reproduced the CI step's exact invocation (`pip install pyright fake-bpy-module-4.5` + `pyright --pythonpath "$(command -v python3)"` with that interpreter first on `PATH`) against this branch - 0 errors.
- [ ] Confirm the `typecheck` job goes green in GitHub Actions once pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6RHzeSdbxz1afiWXX2Tve