### PR TITLE
CI: only run test workflow's push trigger on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+    branches: [ master ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- `test.yml`'s unrestricted `push:` trigger fired the smoke test for every push to any branch, in addition to the `pull_request:` trigger firing on the PR's synchronize event for the same commit — so any push to a branch with an open PR ran the test suite twice.
- Restrict `push:` to `master` only (matching `main.yml`'s existing pattern), keep `pull_request:` for feature-branch/PR coverage.

## Test plan
- [x] YAML is a one-line addition, mirrors `main.yml`'s existing `branches: [ master ]` restriction
- [x] Confirm on GitHub that a push to this PR's branch triggers only one `Test` run (the `pull_request` one), not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6RHzeSdbxz1afiWXX2Tve