### PR TITLE
Test CI against minimum supported Blender version (4.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,15 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 4.1 is the minimum version declared in __init__.py's bl_info; 4.5 is the
+        # latest confirmed-working version (see CLAUDE.md's "Known Blender version
+        # support"). Blender 5.0 is known-broken and deliberately not tested here.
+        blender-version: ["4.1", "4.5"]
     container:
-      image: blenderkit/headless-blender:blender-4.5-stable
+      image: blenderkit/headless-blender:blender-${{ matrix.blender-version }}-stable
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- `bl_info` in `__init__.py` declares Blender 4.1 as the minimum supported version, but CI only ran the headless test suite against 4.5.
- Matrices `smoke-test` across `blender-version: ["4.1", "4.5"]` so both the declared minimum and the latest confirmed-working version are checked on every push/PR.
- Verified locally via podman that all three cases (`smoke`, `export`, `roundtrip`) pass against `blenderkit/headless-blender:blender-4.1-stable` before opening this.

Addresses part of #49 ("run tests against minimum version listed in plug-in metadata").

## Test plan
- [x] Local run against `blender-4.1-stable` via podman: smoke/export/roundtrip all PASS
- [x] CI matrix run on this PR (both 4.1 and 4.5 legs green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZHyLm1JK6CrsD4BCFmsb1