### PR TITLE
Add versioned-release workflow and document release policy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Nightly
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v*.*.*" ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on master
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/master
+
+      - name: Create build dir
+        run: mkdir build
+
+      - name: Compile Manual
+        # TODO: run `make build/jediacademy_plugins_doc.pdf` instead,
+        # but that requires pdflatex to be installed
+        uses: dante-ev/latex-action@latest
+        with:
+          working_directory: build
+          root_file: ../jediacademy_plugins_doc.tex
+
+      - name: Package plugin
+        run: make build/jediacademy.zip
+
+      - name: Extract release notes from tagged commit
+        id: notes
+        run: |
+          {
+            echo "body<<RELEASE_NOTES_EOF"
+            git log -1 --format=%B "$GITHUB_SHA"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.ref_name }}
+          body: |
+            The jediacademy.zip file can be installed using the button in Blender's add-on preferences.
+
+            Please consult jediacademy_plugins_doc.pdf for instructions on how to use the plugin.
+
+            ${{ steps.notes.outputs.body }}
+          files: |
+            build/jediacademy_plugins_doc.pdf
+            build/jediacademy.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,33 @@ confirmed-working version; Blender 5.0 is known to break the plugin (breaking AP
 diagnosing failures reported against a specific Blender version, check that version against this before
 assuming a code bug.
 
+### Releases
+
+Versioned releases use plain SemVer (`bl_info["version"]` in `__init__.py`), decoupled from Blender
+compatibility: `bl_info["blender"]` separately tracks the minimum supported Blender version, and which
+version(s) a release was tested against is stated in the release notes / CI matrix, not encoded into the
+version number itself. **Dropping support for a Blender version (raising the stated minimum) is a breaking
+change and bumps the major version.**
+
+The manual's changelog (`jediacademy_plugins_doc.tex`, "Changelog" section) tracks entries by version
+rather than by date going forward. A PR with a user-facing change adds a bullet under a
+`\subsection*{next version}` placeholder heading (create it if it doesn't exist yet) — internal-only
+changes (CI, test infra, refactors, type annotations) are excluded, per the convention established in
+PR #93. Cutting a release renames that placeholder heading to the real version, e.g.
+`\subsection*{1.0.0}`; existing dated entries from before this convention are left as historical record,
+not retroactively renamed.
+
+To cut a release:
+1. Open a PR that bumps `bl_info["version"]`, renames the changelog's `next version` placeholder to the
+   real version number, and has a commit message written *as the release notes* — it becomes the GitHub
+   Release body verbatim.
+2. After that PR merges to `master`, tag `master`'s HEAD `vX.Y.Z` and push the tag.
+   `.github/workflows/release.yml` then builds the zip/manual and publishes the GitHub Release
+   automatically — it only publishes for tags reachable from `master` (a merge-base check guards against
+   a stray tag on some other commit).
+3. The rolling `nightly` prerelease (`.github/workflows/main.yml`) is unaffected and keeps building on
+   every push to `master` alongside versioned releases.
+
 ### Testing (planned direction)
 
 When implementing test infrastructure for this repo, the intended approach is:
@@ -53,9 +80,7 @@ When implementing test infrastructure for this repo, the intended approach is:
 - Comparisons must be logical, not byte-for-byte: see "Roundtripping" below for why, and for the one exception
   (bone order) that does need to be pinned down explicitly in test fixtures via the reference-skeleton export
   option.
-- Releases should move from the current single rolling `nightly` prerelease to versioned releases that state
-  which Blender version(s) they were tested against, so users on newer/older Blender know whether a release is
-  expected to work for them.
+- Releases are now versioned — see "Releases" above rather than treating this as still-planned.
 
 ### Roundtripping
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@ files, compare). If asked to add tests, see "Testing" below for the intended dir
   `build/jediacademy_plugins_doc.pdf` (compiled from `jediacademy_plugins_doc.tex` via `pdflatex`).
 - `make build/jediacademy.zip` — package just the add-on `.py` files (see `PY_FILES` in `Makefile`) plus
   the readme into a zip installable via Blender's add-on preferences.
-- CI (`.github/workflows/main.yml`) runs on every push to `master`: builds the manual and zip, then
-  force-updates a `nightly` prerelease tag/release with the new build. There is no lint or test step in CI
-  today.
+- `.github/workflows/nightly.yml` runs on every push to `master`: builds the manual and zip, then
+  force-updates a `nightly` prerelease tag/release with the new build. Testing and typechecking run
+  separately in `.github/workflows/test.yml` (see "Testing" below).
 - Formatting/linting: pycodestyle via `.pep8` (only rule disabled: E501 line length, to allow long
   `# pyright: ignore` comments). VS Code is configured (`.vscode/settings.json`) to use `autopep8` as the
   Python formatter and pyright type checking at `standard` mode. There's no separate CLI lint command
@@ -62,7 +62,7 @@ To cut a release:
    `.github/workflows/release.yml` then builds the zip/manual and publishes the GitHub Release
    automatically — it only publishes for tags reachable from `master` (a merge-base check guards against
    a stray tag on some other commit).
-3. The rolling `nightly` prerelease (`.github/workflows/main.yml`) is unaffected and keeps building on
+3. The rolling `nightly` prerelease (`.github/workflows/nightly.yml`) is unaffected and keeps building on
    every push to `master` alongside versioned releases.
 
 ### Testing (planned direction)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml`, triggered on `vX.Y.Z` tag pushes: builds the manual + zip and publishes a GitHub Release using the tagged commit's message as the body.
- Guards against publishing for a tag that isn't reachable from `master` (`git merge-base --is-ancestor`) — tags aren't branch-scoped in git, so nothing else would stop a stray tag on some other commit from triggering a release.
- Documents the versioning scheme in `CLAUDE.md`'s new "Releases" section: plain SemVer (`bl_info["version"]`) decoupled from Blender compatibility (`bl_info["blender"]`); dropping support for a Blender version is a breaking (major) change; the manual's changelog now accumulates entries under a `next version` placeholder heading instead of dates, renamed to the real version at release time.
- Trims the now-stale "should move to versioned releases" forward-looking sentence in the existing "Testing (planned direction)" section.

This is infra + policy only — no actual release is cut here. Part of #74; the follow-up PR bumping `bl_info["version"]` to `1.0.0` and pushing the `v1.0.0` tag closes it.

## Test plan
- [ ] Can't fully dry-run a tag-triggered workflow before merging (GitHub reads workflow files from the pushed ref) — real verification happens when the `v1.0.0` tag is pushed in the follow-up PR.
- [x] YAML reviewed by hand for correctness (mirrors the existing `main.yml` nightly-release job structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZHyLm1JK6CrsD4BCFmsb1