### PR TITLE
Release v1.0.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,6 +41,7 @@ bl_info = {
     "name": "Jedi Academy Import/Export Tools",
     "author": "mrwonko, Cagelight et al",
     "description": "Various Jedi Knight: Jedi Academy related tools: Importers for ASE, GLA, GLM, ROFF and Exporters for ASE, GLA, GLM, animation.cfg, ROFF",
+    "version": (1, 0, 0),
     "blender": (4, 1, 0),
     "location": "File > Import-Export",
     "category": "Import-Export"

--- a/jediacademy_plugins_doc.tex
+++ b/jediacademy_plugins_doc.tex
@@ -119,6 +119,14 @@
   \item Fixed meshes without vertices causing export errors.
  \end{itemize}
 
+ \subsection*{1.0.0}
+ First versioned release since 0.2.2 (2014) -- this project has otherwise shipped nightly builds
+ only. Releases will now carry semantic version numbers going forward, alongside the continuing
+ nightly build.
+ \begin{itemize}
+  \item Fixed import of translating bones (e.g. Howler's tongue) failing due to connected bones.
+ \end{itemize}
+
  \section{Installation}
  
  Open the User Preferences (File/User Preferences or Ctrl+Alt+U), go to the Addons tab and press there


### PR DESCRIPTION
## Summary
- Bumps `bl_info["version"]` to `(1, 0, 0)` — first time this addon has had a version number.
- Adds the `1.0.0` changelog entry to `jediacademy_plugins_doc.tex`, per the `next version`-placeholder convention documented in `CLAUDE.md`'s "Releases" section (no prior placeholder existed yet since this PR establishes the convention).
- Commit message is written as the release notes — `.github/workflows/release.yml` will use it verbatim as the GitHub Release body once the `v1.0.0` tag is pushed after this merges.

Closes #74.

## Test plan
- [x] `pdflatex jediacademy_plugins_doc.tex` compiles cleanly (11 pages, no errors)
- [ ] After merge: tag `master`'s HEAD `v1.0.0`, push the tag, confirm `release.yml` publishes a `v1.0.0` GitHub Release with correct body + attached zip/PDF, confirm #74 auto-closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZHyLm1JK6CrsD4BCFmsb1