### PR TITLE
Fix release doc: tag the version-bump commit, not master's HEAD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,12 @@ To cut a release:
 1. Open a PR that bumps `bl_info["version"]`, renames the changelog's `next version` placeholder to the
    real version number, and has a commit message written *as the release notes* — it becomes the GitHub
    Release body verbatim.
-2. After that PR merges to `master`, tag `master`'s HEAD `vX.Y.Z` and push the tag.
+2. After that PR merges to `master`, tag `vX.Y.Z` and push the tag. **This repo merges PRs as merge
+   commits, so `master`'s HEAD right after merging is a "Merge pull request #N..." commit, not the
+   version-bump commit** — `release.yml` reads the tagged commit's message verbatim as the release notes,
+   so tag the version-bump commit itself (its SHA is the PR branch's tip, e.g. from `gh pr view <N>
+   --json commits`), not `master`'s literal HEAD. It just needs to be reachable from `master`, not be its
+   tip — verified via `git log --graph` before tagging.
    `.github/workflows/release.yml` then builds the zip/manual and publishes the GitHub Release
    automatically — it only publishes for tags reachable from `master` (a merge-base check guards against
    a stray tag on some other commit).


### PR DESCRIPTION
## Summary
Cutting v1.0.0 just now surfaced a gap in the release process doc: this repo merges PRs as merge commits, so `master`'s HEAD right after merging the release PR is a `Merge pull request #N...` commit, not the version-bump commit itself. `release.yml` reads the tagged commit's message verbatim as the GitHub Release body, so tagging `master`'s literal HEAD would've published the merge commit's message ("Merge pull request #98 from mrwonko/release-v1.0.0") instead of the real release notes.

Corrects `CLAUDE.md`'s "Releases" section to say: tag the version-bump commit itself (found via the PR branch's tip SHA), which just needs to be reachable from `master`, not be its literal tip.

## Test plan
- [x] Not applicable — doc-only change; the actual mechanics were exercised live cutting v1.0.0 (see https://github.com/mrwonko/Blender-Jedi-Academy-Tools/releases/tag/v1.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZHyLm1JK6CrsD4BCFmsb1