### PR TITLE
Revert nightly cron to daily (off-peak minute)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ on:
     tags: [ "v*.*.*" ]
   pull_request:
   schedule:
-    # TEMPORARY, for testing the schedule-triggered path (incl. the no-op skip) after merge --
-    # revert to the daily "0 3 * * *" once a few real runs have been confirmed working.
-    - cron: "*/10 * * * *"
+    # Daily, off-peak minute rather than top-of-hour: GitHub Actions schedules cluster at round
+    # minutes/top-of-hour across all repos, causing extra queueing delay.
+    - cron: "17 3 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- The temporary `*/10 * * * *` test cron from #101 has now produced two real scheduled runs, confirming both paths work:
  - A normal tick (changes present): `check-nightly-needed`, `typecheck`, `smoke-test`, and `nightly` all succeeded; `release` correctly skipped (not a tag push).
  - A no-op tick (no changes since last attempt): `check-nightly-needed` ran, everything downstream (`typecheck`/`smoke-test`/`nightly`) correctly skipped instead of re-running against the same commit.
- Reverts to a daily schedule, but at `17 3 * * *` (03:17 UTC) rather than `0 3 * * *`, since GitHub Actions schedules cluster at round minutes/top-of-hour across all repos and an off-peak minute avoids that queueing contention.

## Test plan
- [x] Confirmed via `gh run list --workflow=ci.yml` that both schedule-triggered runs above completed successfully with the expected per-job conclusions.