### PR TITLE
Fix unregister() not removing the GLA Metadata export menu entry

### DIFF
--- a/JAG2Operators.py
+++ b/JAG2Operators.py
@@ -459,5 +459,6 @@ def unregister():
 
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export_glm)
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export_gla)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export_gla_meta)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_glm)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_gla)

--- a/jediacademy_plugins_doc.tex
+++ b/jediacademy_plugins_doc.tex
@@ -127,6 +127,11 @@
   \item Fixed import of translating bones (e.g. Howler's tongue) failing due to connected bones.
  \end{itemize}
 
+ \subsection*{next version}
+ \begin{itemize}
+  \item Fixed disabling the addon leaving its Ghoul 2 Animation Metadata export menu entry in place.
+ \end{itemize}
+
  \section{Installation}
  
  Open the User Preferences (File/User Preferences or Ctrl+Alt+U), go to the Addons tab and press there


### PR DESCRIPTION
## Summary
- `register()` appends `menu_func_export_gla_meta` to `TOPBAR_MT_file_export`, but `unregister()` never removed it — disabling the addon left the "Ghoul 2 Animation Metadata (.cfg)" export entry in the File > Export menu pointing at an unregistered operator.
- Found while auditing `JAG2Operators.py` for a separate Blender 5.0+ compatibility effort; unrelated to that work, so split out as its own fix.

## Test plan
- [x] `tests/run_tests.py` (smoke/export/roundtrip) passes locally via podman against `blenderkit/headless-blender:blender-4.5-stable`.