### PR TITLE
Add check-syntax and blender-tests skills: fixed scripts for two ad-hoc checks

### DIFF
--- a/.claude/skills/blender-tests/SKILL.md
+++ b/.claude/skills/blender-tests/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: blender-tests
+description: Run this repo's headless Blender test suite (tests/run_tests.py) via podman against one or more pinned Blender versions. Use before a commit/PR, or to check cross-version compatibility.
+---
+
+# Run the headless Blender test suite
+
+A fixed script instead of an ad-hoc `podman run ... -v "$(pwd)":/repo:Z ...` invocation, so it can
+be whitelisted in permission settings by exact path rather than needing a broader `podman run *`
+rule (the `$(pwd)`-based mount is what made the ad-hoc version unsafe to whitelist as a fixed
+pattern — every invocation embeds a dynamic shell substitution).
+
+```
+.claude/skills/blender-tests/run_blender_tests.sh <version> [<version> ...]
+# e.g.
+.claude/skills/blender-tests/run_blender_tests.sh 5.2
+.claude/skills/blender-tests/run_blender_tests.sh 4.1 4.5 5.0 5.1 5.2
+```
+
+Pulls `docker.io/blenderkit/headless-blender:blender-<version>-stable` if not already present,
+mounts the repo read-write at `/repo` inside the container, and runs
+`blender --background --python-exit-code 1 --python /repo/tests/run_tests.py`. Exit 0 only if
+every version's test run exits 0. Doesn't rely on the caller's `$(pwd)` or take a repo path — it
+derives the repo root from its own on-disk location, so call it directly from any cwd.
+
+Matches this repo's CI matrix (currently `4.1`/`5.2`, see `.github/workflows/ci.yml`) — use the
+full `4.1 4.5 5.0 5.1 5.2` set for a broader local check before a version-support-affecting
+change, matching what CLAUDE.md's "Known Blender version support" section says has been
+spot-checked.

--- a/.claude/skills/blender-tests/run_blender_tests.sh
+++ b/.claude/skills/blender-tests/run_blender_tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Runs tests/run_tests.py headlessly in one or more versions of Blender via podman.
+# Usage: run_blender_tests.sh <version> [<version> ...]   e.g. run_blender_tests.sh 4.1 5.2
+#
+# Repo root is derived from this script's own location, not the caller's cwd, so the
+# invocation never needs a $(pwd)-style substitution at the call site -- that's what made
+# the equivalent ad-hoc commands unsafe to whitelist as a fixed pattern.
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $(basename "$0") <version> [<version> ...]   e.g. $(basename "$0") 4.1 5.2" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+status=0
+for version in "$@"; do
+  echo "=== Blender $version ==="
+  if ! podman run --rm \
+    --entrypoint /home/headless/blender/blender \
+    -v "$REPO_ROOT:/repo:Z" \
+    "docker.io/blenderkit/headless-blender:blender-${version}-stable" \
+    --background --python-exit-code 1 --python /repo/tests/run_tests.py; then
+    status=1
+  fi
+done
+exit "$status"

--- a/.claude/skills/check-syntax/SKILL.md
+++ b/.claude/skills/check-syntax/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: check-syntax
+description: Validate Python syntax for one or more files via ast.parse, without executing them. Use after editing any .py file in this repo.
+---
+
+# Check Python syntax
+
+A fixed, directly-executable script instead of an ad-hoc `python3 -c "import ast; ...`
+invocation, so it can be whitelisted in permission settings by exact path rather than needing a
+broader rule for arbitrary `python3 -c`/`-m` execution.
+
+```
+.claude/skills/check-syntax/check_syntax.py <file> [<file> ...]
+```
+
+Exit 0 if all files parse; exit 1 and prints `SYNTAX ERROR in <file>: ...` to stderr for any that
+don't. Takes explicit file path arguments and does no shell substitution of its own — that's what
+makes it safe to whitelist by exact path, unlike the ad-hoc `python3 -c` invocation it replaces,
+which would need a much broader rule to allow arbitrary code.

--- a/.claude/skills/check-syntax/check_syntax.py
+++ b/.claude/skills/check-syntax/check_syntax.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate Python syntax for one or more files via ast.parse, without executing them.
+
+Usage: check_syntax.py <file> [<file> ...]
+"""
+import ast
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file> [<file> ...]", file=sys.stderr)
+        return 2
+
+    failed = False
+    for path in sys.argv[1:]:
+        try:
+            with open(path, "r") as f:
+                source = f.read()
+            ast.parse(source, filename=path)
+            print(f"OK: {path}")
+        except SyntaxError as e:
+            failed = True
+            print(f"SYNTAX ERROR in {path}: {e}", file=sys.stderr)
+        except OSError as e:
+            failed = True
+            print(f"ERROR reading {path}: {e}", file=sys.stderr)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds two Claude Code project skills, packaging two commands that came up repeatedly this session as fixed, directly-executable scripts instead of ad-hoc shell invocations:
  - `.claude/skills/check-syntax/check_syntax.py <file> [<file> ...]` — Python syntax validation via `ast.parse`.
  - `.claude/skills/blender-tests/run_blender_tests.sh <version> [<version> ...]` — runs `tests/run_tests.py` headlessly via podman against pinned Blender versions.
- Split into two separate skills rather than one bundling both: they're used at very different points and costs (syntax check after every edit; the Blender test run before a commit/PR), so a single combined description would blur when each is actually relevant — also matches this environment's existing single-purpose skill convention.
- Each is safe to whitelist by exact path for its own reason, not the same reason:
  - `check_syntax.py` takes explicit file arguments and does no shell substitution of its own, replacing an ad-hoc `python3 -c` invocation that would otherwise need a much broader rule to allow arbitrary code.
  - `run_blender_tests.sh` derives the repo root from its own on-disk location rather than the caller's `$(pwd)`, replacing an ad-hoc `podman run` invocation whose `$(pwd)`-based mount embedded a dynamic shell substitution at the call site.
- Purely dev tooling — no changes to the addon itself.

## Test plan
- [x] `check_syntax.py` catches a real syntax error and passes on valid files, called directly from multiple cwds.
- [x] `run_blender_tests.sh` verified to auto-pull a missing image (removed `blender-5.1-stable` locally, confirmed the script pulled it fresh) and run the full suite successfully afterward.