### PR TITLE
Add release skill: end-to-end release process + tag validation

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -70,12 +70,22 @@ Resolves a `#`-prefixed PR number to that PR's branch tip via `gh` (a bare digit
 fail:
 1. The commit is reachable from `origin/master` (the same check the `release` CI job itself
    performs).
-2. `bl_info["version"]` *at that commit* (not the working tree) equals the target version.
-3. `jediacademy_plugins_doc.tex` *at that commit* has the real-version heading from Step 2, not
+2. The commit is **not** a merge commit (has exactly one parent). A clean, non-conflicting
+   "Merge pull request #N" merge has the exact same tree as its non-`master` parent, so checks
+   3/4 below (which only inspect tree content) can't otherwise distinguish a merge commit from
+   the real release commit sitting right under it — this is the actual PR #99 mistake tagging
+   used to hit.
+3. `bl_info["version"]` *at that commit* (not the working tree) equals the target version.
+4. `jediacademy_plugins_doc.tex` *at that commit* has the real-version heading from Step 2, not
    just the `next version` placeholder.
-4. The tag doesn't already exist, locally or on `origin`.
+5. The tag doesn't already exist, locally or on `origin`.
 
-Only if all four pass does it print the commit and prompt for confirmation before actually
+Deliberately **not** checked: whether `smoke-test`/`typecheck` will pass for the tagged commit.
+If the `release` job's `needs` gate fails after tagging, GitHub's normal failure-notification
+email is enough signal — pushing a small follow-up patch release to fix it is an acceptable
+response, so this isn't worth pre-checking here.
+
+Only if all five pass does it print the commit and prompt for confirmation before actually
 tagging and pushing. **This script is deliberately not in the permission auto-allow list** —
 unlike other project skills' scripts, creating and pushing a release tag is a real, hard-to-reverse
 publish action (triggers the `release` job, publishes a public GitHub Release), so it should keep

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: release
+description: Cut a versioned release of this addon end-to-end -- decide the version bump, update the changelog, open the release PR, and tag the merged commit once it's ready. Use when the user asks to cut/push/ship a release.
+---
+
+# Cutting a release
+
+Full process per `CLAUDE.md`'s "Releases" section, with the historically error-prone step (tagging
+the right commit) backed by a validation script. Most steps are plain git/gh commands you already
+know how to run — only Step 5 has a dedicated script, because it's the one step with a documented
+history of mistakes (see PR #99: tagging `master`'s merge-commit HEAD instead of the actual
+version-bump commit, since this repo merges PRs as merge commits).
+
+## Step 1 — Decide whether a version bump is needed, and to what
+
+Gather these facts directly (no script — cheap one-off reads):
+- Most recent released version: latest `\subsection*{X.Y.Z}` heading in
+  `jediacademy_plugins_doc.tex` (equivalently, the latest `vX.Y.Z` git tag: `git tag -l 'v*'`).
+- Current `bl_info["version"]` in `__init__.py`.
+- Bullets currently accumulated under the `\subsection*{next version}` placeholder heading.
+- Commits/PRs merged since the last release tag (`git log <last-tag>..origin/master --oneline`).
+
+**Important nuance**: per `CLAUDE.md`'s "bump immediately in the PR that necessitates it"
+convention, `bl_info["version"]` may *already* have been bumped in some earlier PR, well before
+this release-cutting PR — don't assume every release-cut PR bumps it itself.
+- If `bl_info["version"]` already differs from the last released version: a bump already
+  happened early. Sanity-check the magnitude against the accumulated changelog bullets (e.g. a
+  breaking-change bullet demands major; if `bl_info` only got a minor bump, that's a mismatch to
+  flag) — but don't bump it again if it already looks right.
+- If `bl_info["version"]` still equals the last released version: decide the bump level yourself
+  from the accumulated bullets, using `CLAUDE.md`'s two documented major-bump triggers (dropped
+  Blender version support; a storage-format change that breaks forward-reading by older plugin
+  versions) — major for either, otherwise minor/patch by ordinary judgment. Edit `__init__.py`'s
+  `bl_info["version"]` as part of this same change if a bump is needed now.
+
+## Step 2 — Rename the changelog heading
+
+Edit `jediacademy_plugins_doc.tex`: change `\subsection*{next version}` to the real
+`\subsection*{X.Y.Z}`. Don't touch older dated entries above it.
+
+## Step 3 — Commit with the release notes as the message
+
+Two non-obvious rules:
+- **The commit message becomes the GitHub Release body verbatim** —
+  `.github/workflows/ci.yml`'s `release` job runs `git log -1 --format=%B "$GITHUB_SHA"` on the
+  tagged commit and uses that as the release notes. Write it as real, user-facing release notes,
+  not a normal dev-facing commit message.
+- **Do not** append the usual `Claude-Session`/`Co-Authored-By` trailer to this commit — it would
+  end up in the public release notes.
+
+## Step 4 — Open the PR, wait for merge
+
+Standard branch/PR flow. For "wait for merge": open the PR and stop there — only proceed to Step 5
+once the user confirms it merged, or a fresh `gh pr view <n> --json state` shows `MERGED`. Don't
+poll/auto-wait; this mirrors how every PR in this project actually gets merged (a human decides).
+
+## Step 5 — Tag the correct commit
+
+```
+.claude/skills/release/tag_release.sh <version> <#pr-number|sha>
+# e.g.
+.claude/skills/release/tag_release.sh 2.0.0 '#106'
+.claude/skills/release/tag_release.sh 2.0.0 a1b2c3d
+```
+(Quote the `#pr-number` form — unquoted `#` starts a shell comment.)
+
+Resolves a `#`-prefixed PR number to that PR's branch tip via `gh` (a bare digit string is
+*not* treated as a PR number, since a real commit SHA could in principle be all-decimal-digits —
+`#` is required to disambiguate). Then, in order, refuses with a clear reason if any of these
+fail:
+1. The commit is reachable from `origin/master` (the same check the `release` CI job itself
+   performs).
+2. `bl_info["version"]` *at that commit* (not the working tree) equals the target version.
+3. `jediacademy_plugins_doc.tex` *at that commit* has the real-version heading from Step 2, not
+   just the `next version` placeholder.
+4. The tag doesn't already exist, locally or on `origin`.
+
+Only if all four pass does it print the commit and prompt for confirmation before actually
+tagging and pushing. **This script is deliberately not in the permission auto-allow list** —
+unlike other project skills' scripts, creating and pushing a release tag is a real, hard-to-reverse
+publish action (triggers the `release` job, publishes a public GitHub Release), so it should keep
+prompting every time rather than being whitelisted. The validation logic itself is read-only and
+safe; what's not safe to skip confirming is the tag+push at the end.

--- a/.claude/skills/release/tag_release.sh
+++ b/.claude/skills/release/tag_release.sh
@@ -32,9 +32,17 @@ cd "$REPO_ROOT"
 if [[ "$REF" =~ ^#([0-9]+)$ ]]; then
   PR_NUM="${BASH_REMATCH[1]}"
   echo "Resolving PR #$PR_NUM to its branch tip commit..."
-  SHA="$(gh pr view "$PR_NUM" --json commits --jq '.commits[-1].oid')"
+  # --json headRefOid, not --json commits --jq '.commits[-1].oid': commits is a list that
+  # could in principle be capped for a PR with a huge commit count, whereas headRefOid names
+  # the tip directly. Guarded explicitly (not a bare `SHA=$(...)`) so a resolution failure
+  # (bad PR number, no network) prints our own message instead of a raw gh/GraphQL error.
+  if ! GH_OUTPUT="$(gh pr view "$PR_NUM" --json headRefOid --jq '.headRefOid' 2>&1)"; then
+    echo "ERROR: couldn't resolve PR #$PR_NUM to a commit SHA: $GH_OUTPUT" >&2
+    exit 1
+  fi
+  SHA="$GH_OUTPUT"
   if [ -z "$SHA" ]; then
-    echo "ERROR: couldn't resolve PR #$PR_NUM to a commit SHA" >&2
+    echo "ERROR: couldn't resolve PR #$PR_NUM to a commit SHA (empty result)" >&2
     exit 1
   fi
   echo "PR #$PR_NUM tip: $SHA"
@@ -49,16 +57,36 @@ fail() {
   exit 1
 }
 
-# 1. Commit must exist and be reachable from origin/master -- the same check ci.yml's release
-#    job performs; catching it here means a bad tag never reaches the point of confusing CI.
+# 1. Commit must exist and be reachable from origin/master. This mirrors ci.yml's release job's
+#    own "Verify tag is on master" step (kept in sync by hand -- both are one `git merge-base`
+#    line, not worth extracting a shared script for); catching it here means a bad tag never
+#    reaches the point of confusing CI.
 git cat-file -e "${SHA}^{commit}" 2>/dev/null || fail "commit $SHA does not exist"
 git merge-base --is-ancestor "$SHA" origin/master \
   || fail "commit $SHA is not reachable from origin/master"
 
+# 1b. Must not be a merge commit. A clean, non-conflicting "Merge pull request #N" merge has
+#     the exact same tree as its non-master parent, so checks 2/3 below (which only inspect
+#     tree content) can't otherwise tell a merge commit apart from the real release commit
+#     sitting right under it -- the actual PR #99 mistake this script exists to prevent.
+# `grep -c` exits nonzero when it finds zero matches (a 0-parent root commit, unrealistic as an
+# actual release target but still worth not crashing on) -- `|| true` neutralizes that under
+# `set -o pipefail`, same reasoning as the bl_info check above.
+PARENT_COUNT="$(git cat-file -p "$SHA" | grep -c '^parent ' || true)"
+if [ "$PARENT_COUNT" -gt 1 ]; then
+  fail "commit $SHA has $PARENT_COUNT parents (a merge commit) -- tag the actual release commit (e.g. the PR branch tip), not a merge commit sitting on top of it"
+fi
+
 # 2. bl_info["version"] AT THAT COMMIT (not the working tree) must equal the target version.
-BL_INFO_VERSION="$(git show "$SHA:__init__.py" \
+#    `|| true` on the pipeline plus an explicit empty-string check, rather than a bare
+#    assignment: under `set -o pipefail`, a no-match here (grep finds nothing) would otherwise
+#    abort the whole script silently, before ever reaching the friendly `fail` message below.
+BL_INFO_VERSION="$(git show "$SHA:__init__.py" 2>/dev/null \
   | grep -oP '"version":\s*\(\K[0-9]+,\s*[0-9]+,\s*[0-9]+' \
-  | tr -d ' ' | tr ',' '.')"
+  | tr -d ' ' | tr ',' '.' || true)"
+if [ -z "$BL_INFO_VERSION" ]; then
+  fail "couldn't find bl_info[\"version\"] in __init__.py at $SHA (wrong format, or file missing at that commit?)"
+fi
 if [ "$BL_INFO_VERSION" != "$VERSION" ]; then
   fail "bl_info[\"version\"] at $SHA is ($BL_INFO_VERSION), expected ($VERSION)"
 fi
@@ -74,15 +102,32 @@ fi
 if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
   fail "tag v${VERSION} already exists locally"
 fi
-if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
+# --exit-code: 0 = tag found, 2 = no matching ref (genuinely doesn't exist), anything else is a
+# real failure (network/auth). Checked explicitly rather than piping into `grep -q .`, which
+# can't tell "found nothing" apart from "ls-remote itself failed and printed nothing" -- the
+# latter would otherwise silently pass this check instead of failing loudly.
+set +e
+git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1
+REMOTE_TAG_STATUS=$?
+set -e
+if [ "$REMOTE_TAG_STATUS" -eq 0 ]; then
   fail "tag v${VERSION} already exists on origin"
+elif [ "$REMOTE_TAG_STATUS" -ne 2 ]; then
+  fail "couldn't check whether tag v${VERSION} exists on origin (git ls-remote exited $REMOTE_TAG_STATUS -- network/auth issue?)"
 fi
 
 echo "READY: $SHA passes all checks for v${VERSION}."
 echo
 git log -1 --format='commit %H%nauthor %an%n%n%B' "$SHA"
 echo
-read -r -p "Create and push tag v${VERSION} at this commit? [y/N] " confirm
+# `read` fails (nonzero) on EOF -- e.g. no interactive terminal attached, which is the normal
+# case when this script is run via an agent's non-interactive shell tool rather than directly in
+# a terminal. Guarded explicitly so that case gets its own clear message instead of silently
+# exiting with no output at all (indistinguishable from a real check failing above).
+if ! read -r -p "Create and push tag v${VERSION} at this commit? [y/N] " confirm; then
+  echo "ERROR: couldn't read a confirmation answer (no interactive terminal attached?). Re-run this script directly in an interactive shell to confirm and push the tag." >&2
+  exit 1
+fi
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
   echo "Aborted, no tag created."
   exit 1

--- a/.claude/skills/release/tag_release.sh
+++ b/.claude/skills/release/tag_release.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Validates a release commit and, only if every check passes, tags and pushes it.
+#
+# Usage: tag_release.sh <version> <#pr-number|sha>
+#   version        e.g. 2.0.0 (no leading "v")
+#   #pr-number     a leading "#" resolves to that PR's branch tip via `gh` (e.g. "#106")
+#   sha             anything else is treated as a literal commit SHA -- a raw all-digit string
+#                   is NOT treated as a PR number, since a real commit SHA could (in principle)
+#                   consist entirely of decimal digits; "#" is required to mean "PR number".
+#
+# Repo root is derived from this script's own location, not the caller's cwd -- same reasoning
+# as the check-syntax/blender-tests skills' scripts.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $(basename "$0") <version> <#pr-number|sha>   e.g. $(basename "$0") 2.0.0 '#106'" >&2
+  exit 2
+fi
+
+VERSION="$1"
+REF="$2"
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: version must look like X.Y.Z (no leading 'v'), got: $VERSION" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ "$REF" =~ ^#([0-9]+)$ ]]; then
+  PR_NUM="${BASH_REMATCH[1]}"
+  echo "Resolving PR #$PR_NUM to its branch tip commit..."
+  SHA="$(gh pr view "$PR_NUM" --json commits --jq '.commits[-1].oid')"
+  if [ -z "$SHA" ]; then
+    echo "ERROR: couldn't resolve PR #$PR_NUM to a commit SHA" >&2
+    exit 1
+  fi
+  echo "PR #$PR_NUM tip: $SHA"
+else
+  SHA="$REF"
+fi
+
+git fetch origin --quiet
+
+fail() {
+  echo "NOT READY: $1" >&2
+  exit 1
+}
+
+# 1. Commit must exist and be reachable from origin/master -- the same check ci.yml's release
+#    job performs; catching it here means a bad tag never reaches the point of confusing CI.
+git cat-file -e "${SHA}^{commit}" 2>/dev/null || fail "commit $SHA does not exist"
+git merge-base --is-ancestor "$SHA" origin/master \
+  || fail "commit $SHA is not reachable from origin/master"
+
+# 2. bl_info["version"] AT THAT COMMIT (not the working tree) must equal the target version.
+BL_INFO_VERSION="$(git show "$SHA:__init__.py" \
+  | grep -oP '"version":\s*\(\K[0-9]+,\s*[0-9]+,\s*[0-9]+' \
+  | tr -d ' ' | tr ',' '.')"
+if [ "$BL_INFO_VERSION" != "$VERSION" ]; then
+  fail "bl_info[\"version\"] at $SHA is ($BL_INFO_VERSION), expected ($VERSION)"
+fi
+
+# 3. The changelog must have a heading for this real version at that commit, i.e. the
+#    \subsection*{next version} placeholder was already renamed there.
+if ! git show "$SHA:jediacademy_plugins_doc.tex" \
+    | grep -qF "\\subsection*{${VERSION}}"; then
+  fail "jediacademy_plugins_doc.tex at $SHA has no \\subsection*{${VERSION}} heading"
+fi
+
+# 4. Tag must not already exist, locally or on origin.
+if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+  fail "tag v${VERSION} already exists locally"
+fi
+if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q .; then
+  fail "tag v${VERSION} already exists on origin"
+fi
+
+echo "READY: $SHA passes all checks for v${VERSION}."
+echo
+git log -1 --format='commit %H%nauthor %an%n%n%B' "$SHA"
+echo
+read -r -p "Create and push tag v${VERSION} at this commit? [y/N] " confirm
+if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  echo "Aborted, no tag created."
+  exit 1
+fi
+
+git tag -a "v${VERSION}" "$SHA" -m "v${VERSION}"
+git push origin "v${VERSION}"
+echo "Pushed tag v${VERSION}. The release job in .github/workflows/ci.yml will pick it up once smoke-test/typecheck pass."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,8 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tag is on master
+        # .claude/skills/release/tag_release.sh's check 1 runs this same command before ever
+        # creating the tag -- if this line changes, check that script's equivalent check too.
         run: git merge-base --is-ancestor "$GITHUB_SHA" origin/master
 
       - name: Create build dir


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/release/`, covering the full release-cutting process from `CLAUDE.md`'s "Releases" section end-to-end: deciding the version bump (correctly handling the case where `bl_info["version"]` was already bumped early in a prior PR, per the "bump immediately in the PR that necessitates it" convention), renaming the changelog's `next version` placeholder, writing the release-notes commit, opening the PR, and tagging the merged commit.
- Most steps are plaintext instructions (plain git/gh commands) — only tagging gets a dedicated script, `tag_release.sh`, since it's the one step with a documented history of mistakes (PR #99: tagging `master`'s merge-commit HEAD instead of the actual version-bump commit, since this repo merges PRs as merge commits).
- `tag_release.sh <version> <#pr-number|sha>` validates, in order: the commit is reachable from `origin/master` (same check the `release` CI job performs), `bl_info["version"]` *at that commit* matches the target version, the changelog has the real-version heading at that commit (not just the placeholder), and the tag doesn't already exist — only then prompts to actually tag and push.
- Deliberately **not** added to the permission auto-allow list, unlike `check-syntax`/`blender-tests`'s scripts — creating and pushing a release tag is a real, hard-to-reverse publish action, so it should keep prompting for confirmation every time. No `--dry-run` flag either: the interactive confirmation at the end already doubles as a safe dry run (answer `N`), and this runs rarely enough (once per release) that the added complexity isn't worth it.

## Test plan
- [x] `bash -n` syntax check.
- [x] Refuses a commit predating the changelog rename.
- [x] Refuses a version mismatch (target version doesn't match `bl_info` at that commit).
- [x] Refuses when the tag already exists (tested against the real `v1.0.0` tag).
- [x] Confirmed `#`-prefixed PR-number resolution against a real merged PR (#105).
- [x] Did not create or push any tag as part of this testing.