### PR TITLE
Release v2.0.0

### DIFF
--- a/jediacademy_plugins_doc.tex
+++ b/jediacademy_plugins_doc.tex
@@ -135,8 +135,6 @@
   \item \textbf{Files saved with this version will not be read correctly by older plugin versions}: how
   Ghoul 2 properties are stored on disk changed to make the above fix possible. Opening an existing
   file saved by an older plugin version still works correctly and upgrades it automatically.
-  \item Fixed selecting an unrelated mesh or armature object (with no Ghoul 2 data of its own) silently
-  adding Ghoul 2 properties to it merely from being displayed in the Properties panel.
  \end{itemize}
 
  \section{Installation}

--- a/jediacademy_plugins_doc.tex
+++ b/jediacademy_plugins_doc.tex
@@ -127,7 +127,7 @@
   \item Fixed import of translating bones (e.g. Howler's tongue) failing due to connected bones.
  \end{itemize}
 
- \subsection*{next version}
+ \subsection*{2.0.0}
  \begin{itemize}
   \item Fixed disabling the addon leaving its Ghoul 2 Animation Metadata export menu entry in place.
   \item Fixed Ghoul 2 properties (surface name/shader/tag/off, skeleton scale) silently failing to be


### PR DESCRIPTION
## Summary
- **Commit 1** (docs fix, ahead of the release commit): removes a changelog bullet for a bug that was introduced and fixed within this same unreleased development cycle -- no released version (1.0.0) ever had it, so listing it as a "fix" would mislead someone upgrading from 1.0.0 into thinking it's a regression fix relative to what they've actually used.
- **Commit 2** (the actual release commit, branch tip): renames the changelog's `next version` placeholder to `2.0.0`. `bl_info["version"]` was already bumped to `(2, 0, 0)` earlier (in the Blender-5.0 `g2_prop` fix PR), so no version-number change here. Its commit message is written as the actual release notes (per `CLAUDE.md`'s Releases process, that commit's message becomes the GitHub Release body verbatim once tagged) -- please review it as such, not as a normal dev commit message.
- First real use of the new `release` skill (`.claude/skills/release/SKILL.md`) end-to-end.

## Test plan
- [x] Confirmed `bl_info["version"]` is already `(2, 0, 0)` and matches the accumulated changelog bullets' severity (a documented forward-incompatibility, correctly justifying the major bump).
- [ ] After merge: tag the version-bump commit (this branch's tip, not `master`'s merge-commit HEAD) via `.claude/skills/release/tag_release.sh 2.0.0 '#107'`.