### PR TITLE
Document the changelog-omits-unshipped-bugs convention

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -20,6 +20,12 @@ Gather these facts directly (no script — cheap one-off reads):
 - Bullets currently accumulated under the `\subsection*{next version}` placeholder heading.
 - Commits/PRs merged since the last release tag (`git log <last-tag>..origin/master --oneline`).
 
+While reading those bullets, check each one actually describes something that reached a real
+user: a bug introduced and fixed before it ever merged to `master` (e.g. caught during the same
+PR's development, or in review) was never in anything a user could have gotten, not even a
+nightly build — remove that bullet rather than list it as a "fix". See `CLAUDE.md`'s changelog
+convention.
+
 **Important nuance**: per `CLAUDE.md`'s "bump immediately in the PR that necessitates it"
 convention, `bl_info["version"]` may *already* have been bumped in some earlier PR, well before
 this release-cutting PR — don't assume every release-cut PR bumps it itself.
@@ -47,6 +53,10 @@ Two non-obvious rules:
   not a normal dev-facing commit message.
 - **Do not** append the usual `Claude-Session`/`Co-Authored-By` trailer to this commit — it would
   end up in the public release notes.
+
+Same never-reached-a-user check from Step 1 applies here too — don't carry a bullet for an
+unshipped bug into the release-notes commit message just because it's still in the `.tex` file at
+this point; catching it in Step 1 should have already removed it.
 
 ## Step 4 — Open the PR, wait for merge
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,11 @@ The manual's changelog (`jediacademy_plugins_doc.tex`, "Changelog" section) trac
 rather than by date going forward. A PR with a user-facing change adds a bullet under a
 `\subsection*{next version}` placeholder heading (create it if it doesn't exist yet) — internal-only
 changes (CI, test infra, refactors, type annotations) are excluded, per the convention established in
-PR #93. Cutting a release renames that placeholder heading to the real version, e.g.
+PR #93. **Also excluded: a bug introduced and fixed before it ever reached `master`** (e.g. caught
+during the same PR's development, or in review, before merging) — `master` feeds the rolling
+`nightly` prerelease continuously, so a bug that never merged there was never available to any real
+user, not even a nightly-build one. Listing it as a "fix" would misleadingly imply a past release
+had that regression. Cutting a release renames that placeholder heading to the real version, e.g.
 `\subsection*{1.0.0}`; existing dated entries from before this convention are left as historical record,
 not retroactively renamed.
 


### PR DESCRIPTION
## Summary
- Documents in `CLAUDE.md` that a changelog/release-notes bullet must describe a bug that actually reached `master` (and thus a nightly build), not one caught and fixed before merging.
- Adds matching reminders to the `release` skill's Step 1 (reviewing accumulated bullets) and Step 3 (writing the release-notes commit).

## Context
Caught while cutting v2.0.0 (#107): the draft release notes included a bullet for a bug that was introduced and fixed within the same still-open PR, so no user — not even a nightly-build one — ever saw it. Removed there; this PR makes the convention explicit so it's caught proactively next time.

## Test plan
- [x] Docs-only change, no code affected.