### PR TITLE
Move install-instructions boilerplate to the end of release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,13 +148,13 @@ jobs:
           body: |
             Automatic pre-release build.
 
-            The jediacademy.zip file can be installed using the button in Blender's add-on preferences.
-
-            Please consult jediacademy_plugins_doc.pdf for instructions on how to use the plugin.
-
             Latest change:
 
             ${{ steps.notes.outputs.body }}
+
+            The jediacademy.zip file can be installed using the button in Blender's add-on preferences.
+
+            Please consult jediacademy_plugins_doc.pdf for instructions on how to use the plugin.
           files: |
             build/jediacademy_plugins_doc.pdf
             build/jediacademy.zip
@@ -201,11 +201,11 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           body: |
+            ${{ steps.notes.outputs.body }}
+
             The jediacademy.zip file can be installed using the button in Blender's add-on preferences.
 
             Please consult jediacademy_plugins_doc.pdf for instructions on how to use the plugin.
-
-            ${{ steps.notes.outputs.body }}
           files: |
             build/jediacademy_plugins_doc.pdf
             build/jediacademy.zip


### PR DESCRIPTION
## Summary
- In both the `nightly` and `release` jobs' `action-gh-release` bodies, the generic "install via add-on preferences / see the PDF manual" boilerplate now comes after the actual release notes instead of before them.

## Context
Link-preview cards (Discord, Slack, etc.) only render the first few lines of a GitHub Release body. With the boilerplate first, that's all any card ever showed, hiding the actual changelog/commit-message content. Pure text reordering, no wording changes.

## Test plan
- [x] Diff reviewed: only reorders existing lines, doesn't change any text.
- [ ] Will show up correctly on the next nightly build and the next tagged release.